### PR TITLE
listen to custom event for auth creds and store them on chrome local storage

### DIFF
--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -53,7 +53,7 @@ addEventListener("install", () => {
 	// TODO test if this works on other browsers
 	// TODO2 Read from environment variable the correct URL to redirect after install
 	chrome.tabs.create({
-		url: "https://mocksi-auth.onrender.com/",
+		url: "http://localhost:3030",
 	});
 });
 
@@ -102,7 +102,7 @@ function sendData(request: Map<string, any>) {
 		// problems with unicode data
 		const dataStr = JSON.stringify(data);
 		const encodedDataStr = encodeURIComponent(dataStr);
-		webSocket?.send(btoa(encodedDataStr));
+		// webSocket?.send(btoa(encodedDataStr));
 	});
 }
 
@@ -306,6 +306,13 @@ chrome.runtime.onMessage.addListener(
 			return true;
 		}
 
+		if (request.message === "AuthEvent") {
+			chrome.storage.local.get(["mocksi-auth"], (result) => {
+				const parsed = JSON.parse(result["mocksi-auth"]);
+				console.log("Auth Credentials:", parsed);
+			});
+		}
+
 		sendResponse({ message: request.message, status: "fail" });
 		return false; // No async response for other messages
 	},
@@ -313,6 +320,7 @@ chrome.runtime.onMessage.addListener(
 
 console.log("background script loaded");
 
+/*
 let webSocket = new WebSocket(WebSocketURL);
 
 webSocket.onopen = () => {
@@ -411,3 +419,4 @@ function keepAlive() {
 		}
 	}, 5 * 1000);
 }
+*/

--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -1,5 +1,5 @@
 import { COOKIE_NAME } from "./consts";
-import { WebSocketURL } from "./content/constants";
+import { SignupURL, WebSocketURL } from "./content/constants";
 import { apiCall } from "./networking";
 
 export interface Alteration {
@@ -51,9 +51,8 @@ interface ChromeMessageWithData extends ChromeMessage {
 const requestInterceptions: Map<string, RequestInterception> = new Map();
 addEventListener("install", () => {
 	// TODO test if this works on other browsers
-	// TODO2 Read from environment variable the correct URL to redirect after install
 	chrome.tabs.create({
-		url: "http://localhost:3030",
+		url: SignupURL,
 	});
 });
 
@@ -70,6 +69,7 @@ interface DataPayload {
 }
 
 let loginToken = "";
+let credsJson = "";
 
 // TODO: create a type for the request
 // biome-ignore lint/suspicious/noExplicitAny: this is hard to type
@@ -102,7 +102,7 @@ function sendData(request: Map<string, any>) {
 		// problems with unicode data
 		const dataStr = JSON.stringify(data);
 		const encodedDataStr = encodeURIComponent(dataStr);
-		// webSocket?.send(btoa(encodedDataStr));
+		webSocket?.send(btoa(encodedDataStr));
 	});
 }
 
@@ -308,8 +308,12 @@ chrome.runtime.onMessage.addListener(
 
 		if (request.message === "AuthEvent") {
 			chrome.storage.local.get(["mocksi-auth"], (result) => {
+				credsJson = result["mocksi-auth"];
+				// TODO: uncomment and store these credentials in a secure way
+				/*
 				const parsed = JSON.parse(result["mocksi-auth"]);
 				console.log("Auth Credentials:", parsed);
+				*/
 			});
 		}
 
@@ -320,7 +324,6 @@ chrome.runtime.onMessage.addListener(
 
 console.log("background script loaded");
 
-/*
 let webSocket = new WebSocket(WebSocketURL);
 
 webSocket.onopen = () => {
@@ -419,4 +422,3 @@ function keepAlive() {
 		}
 	}, 5 * 1000);
 }
-*/

--- a/apps/mocksi-lite/content/constants.ts
+++ b/apps/mocksi-lite/content/constants.ts
@@ -1,5 +1,8 @@
+// FIXME: Move to an environment variable
 const WebSocketURL = "wss://crowllectordb.onrender.com/ws";
+// FIXME: Move to an environment variable
+const SignupURL = "https://nest-auth-ts-merge.onrender.com";
 
 const STORAGE_CHANGE_EVENT = "MOCKSI_STORAGE_CHANGE";
 
-export { WebSocketURL, STORAGE_CHANGE_EVENT };
+export { WebSocketURL, STORAGE_CHANGE_EVENT, SignupURL };

--- a/apps/mocksi-lite/content/constants.ts
+++ b/apps/mocksi-lite/content/constants.ts
@@ -1,3 +1,5 @@
 const WebSocketURL = "wss://crowllectordb.onrender.com/ws";
 
-export { WebSocketURL };
+const STORAGE_CHANGE_EVENT = "MOCKSI_STORAGE_CHANGE";
+
+export { WebSocketURL, STORAGE_CHANGE_EVENT };

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -25,6 +25,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 	sendResponse({ status: "success" });
 });
 
+// LocalStorageChangeEventData defines the structure for local storage change events.
 interface LocalStorageChangeEventData {
 	type: string;
 	key: string;
@@ -40,13 +41,11 @@ window.addEventListener("message", (event: MessageEvent) => {
 	}
 
 	console.log("Content script received message: ", eventData);
-	if (eventData.type === STORAGE_CHANGE_EVENT) {
-		chrome.storage.local
-			.set({[eventData.key]: eventData.value })
-			.then(() => {
-				console.log(eventData.key, " set.");
-			});
-		chrome.runtime.sendMessage({ message: "AuthEvent"});
+	if (eventData.type.toUpperCase() === STORAGE_CHANGE_EVENT.toUpperCase()) {
+		chrome.storage.local.set({ [eventData.key]: eventData.value }).then(() => {
+			console.log(eventData.key, " set.");
+		});
+		chrome.runtime.sendMessage({ message: "AuthEvent" });
 	}
 });
 


### PR DESCRIPTION
Depends on https://github.com/Mocksi/nest/pull/10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new constant `STORAGE_CHANGE_EVENT` for handling storage events.
  - Added event listeners for custom storage change events and message passing.

- **Bug Fixes**
  - Updated URL handling for authentication to improve reliability.

- **Refactor**
  - Commented out unused WebSocket-related code and `keepAlive` function to streamline background processes.

- **Chores**
  - Updated message handling in the background script to support new authentication events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->