### PR TITLE
Signout should remove all local storage and navigate back to the login page

### DIFF
--- a/apps/mocksi-lite/consts.ts
+++ b/apps/mocksi-lite/consts.ts
@@ -1,6 +1,9 @@
 export const MOCKSI_RECORDING_STATE = "mocksi-recordingState";
 export const MOCKSI_MODIFICATIONS = "mocksi-modifications";
 export const COOKIE_NAME = "sessionid";
+export const MOCKSI_ACCESS_TOKEN = "mocksi-accessToken";
+export const MOCKSI_USER_ID = "mocksi-userId";
+export const MOCKSI_SESSION_ID = "mocksi-userId";
 
 export enum RecordingState {
 	UNAUTHORIZED = "UNAUTHORIZED",

--- a/apps/mocksi-lite/consts.ts
+++ b/apps/mocksi-lite/consts.ts
@@ -3,7 +3,7 @@ export const MOCKSI_MODIFICATIONS = "mocksi-modifications";
 export const COOKIE_NAME = "sessionid";
 export const MOCKSI_ACCESS_TOKEN = "mocksi-accessToken";
 export const MOCKSI_USER_ID = "mocksi-userId";
-export const MOCKSI_SESSION_ID = "mocksi-userId";
+export const MOCKSI_SESSION_ID = "mocksi-sessionId";
 
 export enum RecordingState {
 	UNAUTHORIZED = "UNAUTHORIZED",

--- a/apps/mocksi-lite/content/ContentApp.tsx
+++ b/apps/mocksi-lite/content/ContentApp.tsx
@@ -1,12 +1,12 @@
-import { useState } from "react";
+import {useState} from "react";
 import TextField from "../common/TextField";
-import { RecordingState } from "../consts";
+import {RecordingState} from "../consts";
 import closeIcon from "../public/close-icon.png";
 import mocksiLogo from "../public/mocksi-logo.png";
-import { setRootPosition } from "../utils";
-import { setEditorMode } from "./EditMode/editMode";
+import {setRootPosition} from "../utils";
+import {setEditorMode} from "./EditMode/editMode";
 import Popup from "./Popup";
-import { RecordButton } from "./RecordButton";
+import {RecordButton} from "./RecordButton";
 
 interface ContentProps {
 	isOpen?: boolean;
@@ -100,7 +100,7 @@ export default function ContentApp({ isOpen, sessionCookie }: ContentProps) {
 					{recordingLabel(state)}
 				</span>
 			</div>
-			{sessionCookie && (
+			{sessionCookie && state !== RecordingState.UNAUTHORIZED && (
 				<RecordButton state={state} onRecordChange={onChangeState} />
 			)}
 		</div>

--- a/apps/mocksi-lite/content/ContentApp.tsx
+++ b/apps/mocksi-lite/content/ContentApp.tsx
@@ -1,12 +1,12 @@
-import {useState} from "react";
+import { useState } from "react";
 import TextField from "../common/TextField";
-import {RecordingState} from "../consts";
+import { RecordingState } from "../consts";
 import closeIcon from "../public/close-icon.png";
 import mocksiLogo from "../public/mocksi-logo.png";
-import {setRootPosition} from "../utils";
-import {setEditorMode} from "./EditMode/editMode";
+import { setRootPosition } from "../utils";
+import { setEditorMode } from "./EditMode/editMode";
 import Popup from "./Popup";
-import {RecordButton} from "./RecordButton";
+import { RecordButton } from "./RecordButton";
 
 interface ContentProps {
 	isOpen?: boolean;

--- a/apps/mocksi-lite/content/Popup/Footer.tsx
+++ b/apps/mocksi-lite/content/Popup/Footer.tsx
@@ -1,15 +1,15 @@
 import { logout } from "../../utils";
 
-const Footer = ({close}: {close: () => void}) => {
+const Footer = ({ close }: { close: () => void }) => {
 	return (
 		<div className={"h-[36px] flex items-center justify-end pr-3"}>
 			<div className={"text-[13px] text-[#5E5E5E] mr-2"}>jana@mocoso.com</div>
 			<div
 				className={"text-[13px] text-[#006C52] underline cursor-pointer"}
 				onClick={() => {
-          close();
-          logout();
-        }}
+					close();
+					logout();
+				}}
 				onKeyUp={(event) => {
 					// todo think something better here
 					event.key === "Enter" && (() => undefined);

--- a/apps/mocksi-lite/content/Popup/Footer.tsx
+++ b/apps/mocksi-lite/content/Popup/Footer.tsx
@@ -1,12 +1,15 @@
 import { logout } from "../../utils";
 
-const Footer = () => {
+const Footer = ({close}: {close: () => void}) => {
 	return (
 		<div className={"h-[36px] flex items-center justify-end pr-3"}>
 			<div className={"text-[13px] text-[#5E5E5E] mr-2"}>jana@mocoso.com</div>
 			<div
 				className={"text-[13px] text-[#006C52] underline cursor-pointer"}
-				onClick={logout}
+				onClick={() => {
+          close();
+          logout();
+        }}
 				onKeyUp={(event) => {
 					// todo think something better here
 					event.key === "Enter" && (() => undefined);

--- a/apps/mocksi-lite/content/Popup/index.tsx
+++ b/apps/mocksi-lite/content/Popup/index.tsx
@@ -50,7 +50,7 @@ const Popup = ({ label, close, setState, state }: PopupProps) => {
 			{!createForm && (
 				<div>
 					<Divider />
-					<Footer />
+					<Footer close={close} />
 				</div>
 			)}
 		</div>

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -17,6 +17,7 @@ export const setRootPosition = (state: RecordingState) => {
 export const logout = () => {
 	document.cookie = `${COOKIE_NAME}=`;
 	localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.UNAUTHORIZED);
+	window.open("https://nest-auth-ts-merge.onrender.com/");
 };
 
 export const saveModification = (

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -1,8 +1,10 @@
 import {
-  COOKIE_NAME, MOCKSI_ACCESS_TOKEN,
-  MOCKSI_MODIFICATIONS,
-  MOCKSI_RECORDING_STATE, MOCKSI_SESSION_ID, MOCKSI_USER_ID,
-  RecordingState,
+	MOCKSI_ACCESS_TOKEN,
+	MOCKSI_MODIFICATIONS,
+	MOCKSI_RECORDING_STATE,
+	MOCKSI_SESSION_ID,
+	MOCKSI_USER_ID,
+	RecordingState,
 } from "./consts";
 
 export const setRootPosition = (state: RecordingState) => {

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -1,8 +1,8 @@
 import {
-	COOKIE_NAME,
-	MOCKSI_MODIFICATIONS,
-	MOCKSI_RECORDING_STATE,
-	RecordingState,
+  COOKIE_NAME, MOCKSI_ACCESS_TOKEN,
+  MOCKSI_MODIFICATIONS,
+  MOCKSI_RECORDING_STATE, MOCKSI_SESSION_ID, MOCKSI_USER_ID,
+  RecordingState,
 } from "./consts";
 
 export const setRootPosition = (state: RecordingState) => {
@@ -15,8 +15,10 @@ export const setRootPosition = (state: RecordingState) => {
 };
 
 export const logout = () => {
-	document.cookie = `${COOKIE_NAME}=`;
 	localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.UNAUTHORIZED);
+	localStorage.removeItem(MOCKSI_ACCESS_TOKEN);
+	localStorage.removeItem(MOCKSI_USER_ID);
+	localStorage.removeItem(MOCKSI_SESSION_ID);
 	window.open("https://nest-auth-ts-merge.onrender.com/");
 };
 


### PR DESCRIPTION
Should we need an endpoint to invalidate that token on the BE?



https://github.com/Mocksi/HARlighter/assets/95246792/51b6c6e6-5fb0-4a09-9527-b14d24bd06ee

