### PR TITLE
[NC]: Email creator filter for get recordings list

### DIFF
--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -1,7 +1,7 @@
 import MocksiRollbar from "./MocksiRollbar";
 import { SignupURL, WebSocketURL } from "./consts";
 import { apiCall } from "./networking";
-import {getEmail} from "./utils";
+import { getEmail } from "./utils";
 
 export interface Alteration {
 	selector: string;

--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -182,6 +182,7 @@ async function getRecordings() {
 	if (email) {
 		const response = await apiCall(`recordings?creator=${email}`);
 		if (!response || response.length === 0) {
+			console.error("No recordings found or failed to fetch recordings.");
 			return;
 		}
 		const sorted = response.sort((a: Recording, b: Recording) =>
@@ -189,6 +190,8 @@ async function getRecordings() {
 		);
 		const recordings = JSON.stringify(sorted) || "[]";
 		chrome.storage.local.set({ recordings });
+	} else {
+		console.error("Email not found. Cannot fetch recordings.");
 	}
 }
 

--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -1,7 +1,7 @@
 import MocksiRollbar from "./MocksiRollbar";
 import { SignupURL, WebSocketURL } from "./consts";
 import { apiCall } from "./networking";
-import { getStorage } from "./utils";
+import {getEmail} from "./utils";
 
 export interface Alteration {
 	selector: string;
@@ -173,9 +173,9 @@ function updateDemo(data: Record<string, unknown>) {
 }
 
 async function getRecordings() {
-	const data = await getStorage();
+	const email = await getEmail();
 
-	const response = await apiCall(`recordings?creator=${data?.email ?? ""}`);
+	const response = await apiCall(`recordings?creator=${email ?? ""}`);
 	if (!response || response.length === 0) {
 		return;
 	}

--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -176,29 +176,6 @@ function updateDemo(data: Record<string, unknown>) {
 	apiCall(`recordings/${id}`, "POST", recording).then(() => getRecordings());
 }
 
-async function getEmail() {
-	const value = await chrome.storage.local.get(STORAGE_KEY);
-	if (!value) {
-		window.open(SignupURL);
-		return;
-	}
-
-	let parsedData: { email: string } | undefined;
-	const storedData = value[STORAGE_KEY] || "{}";
-	try {
-		parsedData = JSON.parse(storedData);
-	} catch (error) {
-		console.log("Error parsing data from storage: ", error);
-		parsedData = undefined;
-	}
-	if (parsedData?.email) {
-		return parsedData.email;
-	}
-
-	MocksiRollbar.log("No email found in storage. Logging out");
-	logout();
-}
-
 async function getRecordings() {
 	const email = await getEmail();
 

--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -174,9 +174,19 @@ function updateDemo(data: Record<string, unknown>) {
 async function getRecordings() {
 	const storage = await chrome.storage.local.get(STORAGE_KEY);
 	const storedData = storage[STORAGE_KEY] || "{}";
-	const { email } = JSON.parse(storedData);
 
-	const response = await apiCall(`recordings?creator=${email ?? ""}`);
+	let parsedData: { email: string } | undefined;
+	try {
+		parsedData = JSON.parse(storedData);
+	} catch (error) {
+		console.log("Error parsing data from storage: ", error);
+		throw new Error("could not parse data from storage.");
+	}
+	if (parsedData === undefined || !parsedData.email) {
+		throw new Error("No email found in storage.");
+	}
+
+	const response = await apiCall(`recordings?creator=${parsedData.email}`);
 	if (!response || response.length === 0) {
 		return;
 	}

--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -1,6 +1,7 @@
 import MocksiRollbar from "./MocksiRollbar";
 import { STORAGE_KEY, SignupURL, WebSocketURL } from "./consts";
 import { apiCall } from "./networking";
+import {getEmail} from "./utils";
 
 export interface Alteration {
 	selector: string;
@@ -172,21 +173,9 @@ function updateDemo(data: Record<string, unknown>) {
 }
 
 async function getRecordings() {
-	const storage = await chrome.storage.local.get(STORAGE_KEY);
-	const storedData = storage[STORAGE_KEY] || "{}";
+	const email = await getEmail();
 
-	let parsedData: { email: string } | undefined;
-	try {
-		parsedData = JSON.parse(storedData);
-	} catch (error) {
-		console.log("Error parsing data from storage: ", error);
-		throw new Error("could not parse data from storage.");
-	}
-	if (parsedData === undefined || !parsedData.email) {
-		throw new Error("No email found in storage.");
-	}
-
-	const response = await apiCall(`recordings?creator=${parsedData.email}`);
+	const response = await apiCall(`recordings?creator=${email ?? ''}`);
 	if (!response || response.length === 0) {
 		return;
 	}

--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -1,5 +1,5 @@
 import MocksiRollbar from "./MocksiRollbar";
-import { SignupURL, WebSocketURL } from "./consts";
+import { STORAGE_KEY, SignupURL, WebSocketURL } from "./consts";
 import { apiCall } from "./networking";
 
 export interface Alteration {
@@ -172,7 +172,11 @@ function updateDemo(data: Record<string, unknown>) {
 }
 
 async function getRecordings() {
-	const response = await apiCall("recordings/");
+	const storage = await chrome.storage.local.get(STORAGE_KEY);
+	const storedData = storage[STORAGE_KEY] || "{}";
+	const { email } = JSON.parse(storedData);
+
+	const response = await apiCall(`recordings?creator=${email ?? ""}`);
 	if (!response || response.length === 0) {
 		return;
 	}

--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -1,7 +1,7 @@
 import MocksiRollbar from "./MocksiRollbar";
-import { STORAGE_KEY, SignupURL, WebSocketURL } from "./consts";
+import { SignupURL, WebSocketURL } from "./consts";
 import { apiCall } from "./networking";
-import {getEmail} from "./utils";
+import { getStorage } from "./utils";
 
 export interface Alteration {
 	selector: string;
@@ -173,9 +173,9 @@ function updateDemo(data: Record<string, unknown>) {
 }
 
 async function getRecordings() {
-	const email = await getEmail();
+	const data = await getStorage();
 
-	const response = await apiCall(`recordings?creator=${email ?? ''}`);
+	const response = await apiCall(`recordings?creator=${data?.email ?? ""}`);
 	if (!response || response.length === 0) {
 		return;
 	}

--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -175,15 +175,17 @@ function updateDemo(data: Record<string, unknown>) {
 async function getRecordings() {
 	const email = await getEmail();
 
-	const response = await apiCall(`recordings?creator=${email ?? ""}`);
-	if (!response || response.length === 0) {
-		return;
+	if (email) {
+		const response = await apiCall(`recordings?creator=${email}`);
+		if (!response || response.length === 0) {
+			return;
+		}
+		const sorted = response.sort((a: Recording, b: Recording) =>
+			a.updated_timestamp > b.updated_timestamp ? -1 : 0,
+		);
+		const recordings = JSON.stringify(sorted) || "[]";
+		chrome.storage.local.set({ recordings });
 	}
-	const sorted = response.sort((a: Recording, b: Recording) =>
-		a.updated_timestamp > b.updated_timestamp ? -1 : 0,
-	);
-	const recordings = JSON.stringify(sorted) || "[]";
-	chrome.storage.local.set({ recordings });
 }
 
 // TODO: create a type for the params

--- a/apps/mocksi-lite/content/ContentApp.tsx
+++ b/apps/mocksi-lite/content/ContentApp.tsx
@@ -7,7 +7,7 @@ import {
 } from "../consts";
 import closeIcon from "../public/close-icon.png";
 import mocksiLogo from "../public/mocksi-logo.png";
-import { sendMessage, setRootPosition } from "../utils";
+import { setRootPosition } from "../utils";
 import { setEditorMode } from "./EditMode/editMode";
 import Popup from "./Popup";
 import { RecordButton } from "./RecordButton";
@@ -45,11 +45,6 @@ export default function ContentApp({ isOpen, email }: ContentProps) {
 	const onChangeState = (newState: RecordingState) => {
 		setState(newState);
 		setRootPosition(newState);
-	};
-
-	const handleUpdate = () => {
-		const id = localStorage.getItem(MOCKSI_RECORDING_ID);
-		sendMessage("updateDemo", { id });
 	};
 
 	if (!isDialogOpen) return null;

--- a/apps/mocksi-lite/content/Popup/CreateDemo/DemoItem.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/DemoItem.tsx
@@ -43,7 +43,11 @@ const DemoItem = ({
 				<Button
 					variant={Variant.icon}
 					onClick={() => loadAlterations(alterations)}
-					disabled={!url.includes(window.location.hostname)}
+					disabled={
+						!url.includes(window.location.hostname) ||
+						!alterations ||
+						!alterations.length
+					}
 				>
 					<img src={exportIcon} alt={"exportIcon"} />
 				</Button>

--- a/apps/mocksi-lite/content/Popup/CreateDemo/Form.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/Form.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import type { Recording } from "../../../background";
 import Button, { Variant } from "../../../common/Button";
 import TextField from "../../../common/TextField";
 import expandIcon from "../../../public/expand-icon.png";
@@ -7,7 +6,7 @@ import { sendMessage } from "../../../utils";
 import Divider from "../Divider";
 
 interface FormProps {
-	onCancel: (recordings?: Recording[]) => void;
+	onCancel: () => void;
 }
 
 const Form = ({ onCancel }: FormProps) => {
@@ -16,16 +15,7 @@ const Form = ({ onCancel }: FormProps) => {
 
 	const handleSubmit = () => {
 		sendMessage("createDemo", { demo_name: name, customer_name: customer });
-		// this is needed to wait until the new data is established
-		setTimeout(() => {
-			try {
-				chrome.storage.local.get(["recordings"], (results) => {
-					onCancel(JSON.parse(results.recordings));
-				});
-			} catch (error) {
-				console.error("Error retrieving recordings:", error);
-			}
-		}, 1000);
+		onCancel();
 	};
 	return (
 		<div className={"flex-1 mt-3"}>
@@ -53,7 +43,7 @@ const Form = ({ onCancel }: FormProps) => {
 						/>
 					</div>
 					<div className={"mt-[42px] flex justify-end gap-4"}>
-						<Button onClick={() => onCancel()} variant={Variant.secondary}>
+						<Button onClick={onCancel} variant={Variant.secondary}>
 							Cancel
 						</Button>
 						<Button disabled={!name.length} onClick={handleSubmit}>

--- a/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
@@ -53,14 +53,16 @@ const CreateDemo = ({
 				<div
 					className={"flex-1 flex flex-col py-8 overflow-y-scroll no-scrollbar"}
 				>
-					{recordings.filter((record) => record.url).map((record) => (
-						<Fragment key={`demo-item-${record.uuid}`}>
-							<DemoItem setState={setState} {...record} />
-							<div className={"px-3 w-full my-6"}>
-								<Divider />
-							</div>
-						</Fragment>
-					))}
+					{recordings
+						.filter((record) => record.url)
+						.map((record) => (
+							<Fragment key={`demo-item-${record.uuid}`}>
+								<DemoItem setState={setState} {...record} />
+								<div className={"px-3 w-full my-6"}>
+									<Divider />
+								</div>
+							</Fragment>
+						))}
 				</div>
 			) : null}
 			<Button

--- a/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
@@ -5,6 +5,7 @@ import type { RecordingState } from "../../../consts";
 import Form from "../CreateDemo/Form";
 import Divider from "../Divider";
 import DemoItem from "./DemoItem";
+import {getRecordingsStorage} from "../../../utils";
 
 interface CreateDemoProps {
 	createForm: boolean;
@@ -23,15 +24,13 @@ const CreateDemo = ({
 		let continueFetching = true;
 		while (continueFetching) {
 			try {
-				const results = await chrome.storage.local.get(["recordings"]);
-				const newRecordings = JSON.parse(results.recordings ?? "{}");
+				const newRecordings = await getRecordingsStorage();
 				if (newRecordings.length !== recordings.length) {
 					setRecordings(newRecordings);
 					continueFetching = false; // Stop the loop if recordings have been updated
 				}
 			} catch (error) {
 				continueFetching = false; // Stop the loop in case of an error
-				console.error("Failed to fetch recordings:", error);
 			}
 		}
 	};

--- a/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useEffect, useState } from "react";
 import type { Recording } from "../../../background";
 import Button from "../../../common/Button";
-import type { RecordingState } from "../../../consts";
+import { RecordingState } from "../../../consts";
 import { getRecordingsStorage } from "../../../utils";
 import Form from "../CreateDemo/Form";
 import Divider from "../Divider";
@@ -11,12 +11,14 @@ interface CreateDemoProps {
 	createForm: boolean;
 	setCreateForm: (value: boolean) => void;
 	setState: (r: RecordingState) => void;
+	state: RecordingState;
 }
 
 const CreateDemo = ({
 	createForm,
 	setCreateForm,
 	setState,
+	state,
 }: CreateDemoProps) => {
 	const [recordings, setRecordings] = useState<Recording[]>([]);
 
@@ -25,7 +27,6 @@ const CreateDemo = ({
 		while (continueFetching) {
 			try {
 				const newRecordings = await getRecordingsStorage();
-				console.log({ newRecordings });
 				if (newRecordings.length !== recordings.length) {
 					setRecordings(newRecordings);
 					continueFetching = false; // Stop the loop if recordings have been updated
@@ -38,10 +39,10 @@ const CreateDemo = ({
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies:
 	useEffect(() => {
-		if (!createForm) {
+		if (!createForm && state !== RecordingState.EDITING) {
 			getRecordings();
 		}
-	}, [createForm]);
+	}, [createForm, state]);
 
 	if (createForm) return <Form onCancel={() => setCreateForm(false)} />;
 	return (

--- a/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
@@ -25,6 +25,7 @@ const CreateDemo = ({
 		while (continueFetching) {
 			try {
 				const newRecordings = await getRecordingsStorage();
+				console.log({ newRecordings });
 				if (newRecordings.length !== recordings.length) {
 					setRecordings(newRecordings);
 					continueFetching = false; // Stop the loop if recordings have been updated
@@ -45,18 +46,20 @@ const CreateDemo = ({
 	if (createForm) return <Form onCancel={() => setCreateForm(false)} />;
 	return (
 		<div className={"flex flex-1 flex-col h-[280px]"}>
-			<div
-				className={"flex-1 flex flex-col py-8 overflow-y-scroll no-scrollbar"}
-			>
-				{recordings.map((record) => (
-					<Fragment key={`demo-item-${record.uuid}`}>
-						<DemoItem setState={setState} {...record} />
-						<div className={"px-3 w-full my-6"}>
-							<Divider />
-						</div>
-					</Fragment>
-				))}
-			</div>
+			{recordings.length ? (
+				<div
+					className={"flex-1 flex flex-col py-8 overflow-y-scroll no-scrollbar"}
+				>
+					{recordings.map((record) => (
+						<Fragment key={`demo-item-${record.uuid}`}>
+							<DemoItem setState={setState} {...record} />
+							<div className={"px-3 w-full my-6"}>
+								<Divider />
+							</div>
+						</Fragment>
+					))}
+				</div>
+			) : null}
 			<Button
 				onClick={() => setCreateForm(true)}
 				className={!recordings.length ? "mt-3 self-center" : "my-3 self-center"}

--- a/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
@@ -43,31 +43,24 @@ const CreateDemo = ({
 		}
 	}, [createForm]);
 
-	const handleCancelClick = (recordings?: Recording[]) => {
-		if (recordings) {
-			setRecordings(recordings || []);
-		}
-		setCreateForm(false);
-	};
-
-	if (createForm) return <Form onCancel={handleCancelClick} />;
+	if (createForm) return <Form onCancel={() => setCreateForm(false)} />;
 	return (
-		<div
-			className={
-				"flex-1 flex flex-col items-center py-8 overflow-y-scroll no-scrollbar"
-			}
-		>
-			{recordings.map((record) => (
-				<Fragment key={`demo-item-${record.uuid}`}>
-					<DemoItem setState={setState} {...record} />
-					<div className={"px-3 w-full my-6"}>
-						<Divider />
-					</div>
-				</Fragment>
-			))}
+		<div className={"flex flex-1 flex-col h-[280px]"}>
+			<div
+				className={"flex-1 flex flex-col py-8 overflow-y-scroll no-scrollbar"}
+			>
+				{recordings.map((record) => (
+					<Fragment key={`demo-item-${record.uuid}`}>
+						<DemoItem setState={setState} {...record} />
+						<div className={"px-3 w-full my-6"}>
+							<Divider />
+						</div>
+					</Fragment>
+				))}
+			</div>
 			<Button
 				onClick={() => setCreateForm(true)}
-				className={!recordings.length ? "mt-3" : ""}
+				className={!recordings.length ? "mt-3 self-center" : "my-3 self-center"}
 			>
 				Create New Demo
 			</Button>

--- a/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
@@ -2,10 +2,10 @@ import { Fragment, useEffect, useState } from "react";
 import type { Recording } from "../../../background";
 import Button from "../../../common/Button";
 import type { RecordingState } from "../../../consts";
+import { getRecordingsStorage } from "../../../utils";
 import Form from "../CreateDemo/Form";
 import Divider from "../Divider";
 import DemoItem from "./DemoItem";
-import {getRecordingsStorage} from "../../../utils";
 
 interface CreateDemoProps {
 	createForm: boolean;

--- a/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
@@ -44,7 +44,9 @@ const CreateDemo = ({
 		}
 	}, [createForm, state]);
 
-	if (createForm) return <Form onCancel={() => setCreateForm(false)} />;
+	if (createForm) {
+		return <Form onCancel={() => setCreateForm(false)} />;
+	}
 	return (
 		<div className={"flex flex-1 flex-col h-[280px]"}>
 			{recordings.length ? (

--- a/apps/mocksi-lite/content/Popup/index.tsx
+++ b/apps/mocksi-lite/content/Popup/index.tsx
@@ -29,6 +29,7 @@ const Popup = ({ label, close, setState, state, email }: PopupProps) => {
 						createForm={createForm}
 						setCreateForm={setCreateForm}
 						setState={setState}
+						state={state}
 					/>
 				);
 			default:

--- a/apps/mocksi-lite/content/RecordButton.tsx
+++ b/apps/mocksi-lite/content/RecordButton.tsx
@@ -40,13 +40,13 @@ export const RecordButton = ({ state, onRecordChange }: RecordButtonProps) => {
 		chrome.storage.local.get([MOCKSI_RECORDING_STATE], (result) => {
 			const storageState =
 				(result[MOCKSI_RECORDING_STATE] as RecordingState) ||
-			RecordingState.READY;
+				RecordingState.READY;
 
-		onRecordChange(storageState);
-		if (storageState === RecordingState.ANALYZING) {
-			setTimeout(() => {
-				onRecordChange(RecordingState.CREATE);
-				chrome.storage.local.set({
+			onRecordChange(storageState);
+			if (storageState === RecordingState.ANALYZING) {
+				setTimeout(() => {
+					onRecordChange(RecordingState.CREATE);
+					chrome.storage.local.set({
 						[MOCKSI_RECORDING_STATE]: RecordingState.CREATE.toString(),
 					});
 				}, waitTime);

--- a/apps/mocksi-lite/content/RecordButton.tsx
+++ b/apps/mocksi-lite/content/RecordButton.tsx
@@ -7,6 +7,7 @@ interface RecordButtonProps {
 	onRecordChange: (status: RecordingState) => void;
 	state: RecordingState;
 }
+const waitTime = 2000; // 2 seconds
 
 const recordingColorAndLabel = (currentStatus: RecordingState) => {
 	switch (currentStatus) {
@@ -42,7 +43,6 @@ export const RecordButton = ({ state, onRecordChange }: RecordButtonProps) => {
 			RecordingState.READY;
 
 		onRecordChange(storageState);
-		const waitTime = 2000; // 2 seconds
 		if (storageState === RecordingState.ANALYZING) {
 			setTimeout(() => {
 				onRecordChange(RecordingState.CREATE);
@@ -66,7 +66,7 @@ export const RecordButton = ({ state, onRecordChange }: RecordButtonProps) => {
 					MOCKSI_RECORDING_STATE,
 					RecordingState.CREATE.toString(),
 				);
-			}, 10000);
+			}, waitTime);
 		}
 	};
 

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -29,17 +29,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 			const recordingState = localStorage.getItem(
 				MOCKSI_RECORDING_STATE,
 			) as RecordingState | null;
-			if (email) {
+			if (email && !recordingState) {
 				// we need to initialize recordingState if there's none.
-				!recordingState &&
-					localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.READY);
+				localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.READY);
 			}
-			if (recordingState) {
-				if (recordingState === RecordingState.EDITING) {
-					localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.CREATE);
-				}
-				setRootPosition(recordingState);
+			if (recordingState === RecordingState.EDITING) {
+				localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.CREATE);
 			}
+			setRootPosition(recordingState);
 			root.render(<ContentApp isOpen={true} email={email || ""} />);
 		});
 	}

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -3,10 +3,8 @@ import {
 	MOCKSI_RECORDING_STATE,
 	RecordingState,
 	STORAGE_CHANGE_EVENT,
-	STORAGE_KEY,
-	SignupURL,
 } from "../consts";
-import { getStorage, setRootPosition } from "../utils";
+import {getEmail, setRootPosition} from "../utils";
 import ContentApp from "./ContentApp";
 
 let root: ReactDOM.Root;
@@ -27,11 +25,11 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 			root.unmount();
 		}
 		root = ReactDOM.createRoot(extensionRoot);
-		getStorage().then((data) => {
+		getEmail().then((email) => {
 			const recordingState = localStorage.getItem(
 				MOCKSI_RECORDING_STATE,
 			) as RecordingState | null;
-			if (data?.email) {
+			if (email) {
 				// we need to initialize recordingState if there's none.
 				!recordingState &&
 					localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.READY);
@@ -42,7 +40,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 				}
 				setRootPosition(recordingState);
 			}
-			root.render(<ContentApp isOpen={true} email={data?.email || ""} />);
+			root.render(<ContentApp isOpen={true} email={email || ""} />);
 		});
 	}
 	sendResponse({ status: "success" });

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -4,7 +4,7 @@ import {
 	RecordingState,
 	STORAGE_CHANGE_EVENT,
 } from "../consts";
-import {getEmail, setRootPosition} from "../utils";
+import { getEmail, setRootPosition } from "../utils";
 import ContentApp from "./ContentApp";
 
 let root: ReactDOM.Root;

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -6,7 +6,7 @@ import {
 	STORAGE_KEY,
 	SignupURL,
 } from "../consts";
-import { setRootPosition } from "../utils";
+import {getEmail, setRootPosition} from "../utils";
 import ContentApp from "./ContentApp";
 
 let root: ReactDOM.Root;
@@ -27,43 +27,29 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 			root.unmount();
 		}
 		root = ReactDOM.createRoot(extensionRoot);
-		chrome.storage.local
-			.get(STORAGE_KEY)
-			.then((value) => {
-				let parsedData: { email: string } | undefined;
-				const storedData = value[STORAGE_KEY] || "{}";
-				try {
-					parsedData = JSON.parse(storedData);
-				} catch (error) {
-					console.log("Error parsing data from storage: ", error);
-					throw new Error("could not parse data from storage.");
-				}
-				if (parsedData === undefined || !parsedData.email) {
-					throw new Error("No email found in storage.");
-				}
-
-				const { email } = parsedData || {};
-				const recordingState = localStorage.getItem(
-					MOCKSI_RECORDING_STATE,
-				) as RecordingState | null;
-				if (email) {
-					// we need to initialize recordingState if there's none.
-					!recordingState &&
-						localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.READY);
-				}
-				if (recordingState) {
-					if (recordingState === RecordingState.EDITING) {
-						localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.CREATE);
-					}
-					setRootPosition(recordingState);
-				}
-				root.render(<ContentApp isOpen={true} email={email || ""} />);
-			})
-			.catch((error) => {
-				localStorage.clear();
-				console.log("Error getting data from storage: ", error);
-				window.open(SignupURL);
-			});
+    getEmail()
+      .then((email) => {
+        const recordingState = localStorage.getItem(
+          MOCKSI_RECORDING_STATE,
+        ) as RecordingState | null;
+        if (email) {
+          // we need to initialize recordingState if there's none.
+          !recordingState &&
+          localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.READY);
+        }
+        if (recordingState) {
+          if (recordingState === RecordingState.EDITING) {
+            localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.CREATE);
+          }
+          setRootPosition(recordingState);
+        }
+        root.render(<ContentApp isOpen={true} email={email || ""} />);
+      })
+      .catch((error) => {
+        localStorage.clear();
+        console.log("Error getting data from storage: ", error);
+        window.open(SignupURL);
+      });
 	}
 	sendResponse({ status: "success" });
 });

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -31,14 +31,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 			) as RecordingState | null;
 			if (email && !recordingState) {
 				// we need to initialize recordingState if there's none.
-        chrome.storage.local.set({
-          [MOCKSI_RECORDING_STATE]: RecordingState.READY,
-        });
+				chrome.storage.local.set({
+					[MOCKSI_RECORDING_STATE]: RecordingState.READY,
+				});
 			}
 			if (recordingState === RecordingState.EDITING) {
-        chrome.storage.local.set({
-          [MOCKSI_RECORDING_STATE]: RecordingState.CREATE,
-        });
+				chrome.storage.local.set({
+					[MOCKSI_RECORDING_STATE]: RecordingState.CREATE,
+				});
 			}
 			setRootPosition(recordingState);
 			root.render(<ContentApp isOpen={true} email={email || ""} />);

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -6,7 +6,7 @@ import {
 	STORAGE_KEY,
 	SignupURL,
 } from "../consts";
-import {getEmail, setRootPosition} from "../utils";
+import { getStorage, setRootPosition } from "../utils";
 import ContentApp from "./ContentApp";
 
 let root: ReactDOM.Root;
@@ -27,29 +27,23 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 			root.unmount();
 		}
 		root = ReactDOM.createRoot(extensionRoot);
-    getEmail()
-      .then((email) => {
-        const recordingState = localStorage.getItem(
-          MOCKSI_RECORDING_STATE,
-        ) as RecordingState | null;
-        if (email) {
-          // we need to initialize recordingState if there's none.
-          !recordingState &&
-          localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.READY);
-        }
-        if (recordingState) {
-          if (recordingState === RecordingState.EDITING) {
-            localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.CREATE);
-          }
-          setRootPosition(recordingState);
-        }
-        root.render(<ContentApp isOpen={true} email={email || ""} />);
-      })
-      .catch((error) => {
-        localStorage.clear();
-        console.log("Error getting data from storage: ", error);
-        window.open(SignupURL);
-      });
+		getStorage().then((data) => {
+			const recordingState = localStorage.getItem(
+				MOCKSI_RECORDING_STATE,
+			) as RecordingState | null;
+			if (data?.email) {
+				// we need to initialize recordingState if there's none.
+				!recordingState &&
+					localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.READY);
+			}
+			if (recordingState) {
+				if (recordingState === RecordingState.EDITING) {
+					localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.CREATE);
+				}
+				setRootPosition(recordingState);
+			}
+			root.render(<ContentApp isOpen={true} email={data?.email || ""} />);
+		});
 	}
 	sendResponse({ status: "success" });
 });

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -1,5 +1,4 @@
 import ReactDOM from "react-dom/client";
-import MocksiRollbar from "../MocksiRollbar";
 import {
 	MOCKSI_RECORDING_STATE,
 	RecordingState,
@@ -53,6 +52,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 						localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.READY);
 				}
 				if (recordingState) {
+					if (recordingState === RecordingState.EDITING) {
+						localStorage.setItem(MOCKSI_RECORDING_STATE, RecordingState.CREATE);
+					}
 					setRootPosition(recordingState);
 				}
 				root.render(<ContentApp isOpen={true} email={email || ""} />);

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -5,11 +5,12 @@ import {
 	buildQuerySelector,
 } from "./commands/Command";
 import {
-	MOCKSI_MODIFICATIONS,
-	MOCKSI_RECORDING_STATE,
-	RecordingState,
-	SignupURL,
+  MOCKSI_MODIFICATIONS,
+  MOCKSI_RECORDING_STATE,
+  RecordingState,
+  SignupURL, STORAGE_KEY,
 } from "./consts";
+import MocksiRollbar from "./MocksiRollbar";
 
 type DOMModificationsType = {
 	[querySelector: string]: { nextText: string; previousText: string };
@@ -126,3 +127,22 @@ export const sendMessage = (
 			console.error("Failed to send message to background script");
 		}
 	});
+
+export const getEmail = async(): Promise<string | null> =>  {
+  const value = await chrome.storage.local.get(STORAGE_KEY);
+  if (!value) {
+    window.open(SignupURL);
+    return null;  // Ensure a value is always returned
+  }
+
+  const storedData = value[STORAGE_KEY] || "{}";
+  try {
+    const parsedData: { email: string } = JSON.parse(storedData);
+    return parsedData.email || null;
+  } catch (error) {
+    console.log("Error parsing data from storage: ", error);
+    MocksiRollbar.log("Error parsing email data, logging out.");
+    logout();
+    return null;
+  }
+}

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -10,7 +10,7 @@ import {
   MOCKSI_RECORDING_STATE,
   RecordingState,
   STORAGE_KEY,
-  SignupURL, MOCKSI_AUTH,
+  SignupURL,
 } from "./consts";
 import {Recording} from "./background";
 
@@ -156,6 +156,6 @@ export const getRecordingsStorage = async (): Promise<Recording[]> => {
     return JSON.parse(results.recordings ?? "{}");
   } catch (err) {
     console.error("Failed to retrieve recordings:", err);
-    return [];
+    throw err;
   }
 };

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -1,18 +1,18 @@
 import MocksiRollbar from "./MocksiRollbar";
 import type { Alteration } from "./background";
+import type { Recording } from "./background";
 import {
 	type Command,
 	SaveModificationCommand,
 	buildQuerySelector,
 } from "./commands/Command";
 import {
-  MOCKSI_MODIFICATIONS,
-  MOCKSI_RECORDING_STATE,
-  RecordingState,
-  STORAGE_KEY,
-  SignupURL,
+	MOCKSI_MODIFICATIONS,
+	MOCKSI_RECORDING_STATE,
+	RecordingState,
+	STORAGE_KEY,
+	SignupURL,
 } from "./consts";
-import {Recording} from "./background";
 
 type DOMModificationsType = {
 	[querySelector: string]: { nextText: string; previousText: string };
@@ -149,13 +149,12 @@ export const getEmail = async (): Promise<string | null> => {
 	}
 };
 
-
 export const getRecordingsStorage = async (): Promise<Recording[]> => {
-  try {
-    const results = await chrome.storage.local.get(["recordings"]);
-    return JSON.parse(results.recordings ?? "{}");
-  } catch (err) {
-    console.error("Failed to retrieve recordings:", err);
-    throw err;
-  }
+	try {
+		const results = await chrome.storage.local.get(["recordings"]);
+		return JSON.parse(results.recordings ?? "{}");
+	} catch (err) {
+		console.error("Failed to retrieve recordings:", err);
+		throw err;
+	}
 };

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -152,7 +152,11 @@ export const getEmail = async (): Promise<string | null> => {
 export const getRecordingsStorage = async (): Promise<Recording[]> => {
 	try {
 		const results = await chrome.storage.local.get(["recordings"]);
-		return JSON.parse(results.recordings ?? "{}");
+		console.log(results.recordings);
+		if (results.recordings) {
+			return JSON.parse(results.recordings);
+		}
+		return [];
 	} catch (err) {
 		console.error("Failed to retrieve recordings:", err);
 		throw err;

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -6,24 +6,17 @@ import {
 	buildQuerySelector,
 } from "./commands/Command";
 import {
-	MOCKSI_MODIFICATIONS,
-	MOCKSI_RECORDING_STATE,
-	RecordingState,
-	STORAGE_KEY,
-	SignupURL,
+  MOCKSI_MODIFICATIONS,
+  MOCKSI_RECORDING_STATE,
+  RecordingState,
+  STORAGE_KEY,
+  SignupURL, MOCKSI_AUTH,
 } from "./consts";
+import {Recording} from "./background";
 
 type DOMModificationsType = {
 	[querySelector: string]: { nextText: string; previousText: string };
 };
-interface ChromeStorage {
-	accessToken: string;
-	userId: string;
-	sessionId: string;
-	recordingState: RecordingState;
-	refreshToken: string;
-	email: string;
-}
 
 export const setRootPosition = (state: RecordingState) => {
 	const extensionRoot = document.getElementById("extension-root");
@@ -137,7 +130,7 @@ export const sendMessage = (
 		}
 	});
 
-export const getStorage = async (): Promise<ChromeStorage | null> => {
+export const getEmail = async (): Promise<string | null> => {
 	const value = await chrome.storage.local.get(STORAGE_KEY);
 	if (!value) {
 		window.open(SignupURL);
@@ -147,11 +140,22 @@ export const getStorage = async (): Promise<ChromeStorage | null> => {
 	const storedData = value[STORAGE_KEY] || "{}";
 	try {
 		const parsedData = JSON.parse(storedData);
-		return parsedData;
+		return parsedData.email;
 	} catch (error) {
 		console.log("Error parsing data from storage: ", error);
-		MocksiRollbar.log("Error parsing storage data, logging out.");
+		MocksiRollbar.log("Error parsing email data, logging out.");
 		logout();
 		return null;
 	}
+};
+
+
+export const getRecordingsStorage = async (): Promise<Recording[]> => {
+  try {
+    const results = await chrome.storage.local.get(["recordings"]);
+    return JSON.parse(results.recordings ?? "{}");
+  } catch (err) {
+    console.error("Failed to retrieve recordings:", err);
+    return [];
+  }
 };

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -1,3 +1,4 @@
+import MocksiRollbar from "./MocksiRollbar";
 import type { Alteration } from "./background";
 import {
 	type Command,
@@ -5,16 +6,24 @@ import {
 	buildQuerySelector,
 } from "./commands/Command";
 import {
-  MOCKSI_MODIFICATIONS,
-  MOCKSI_RECORDING_STATE,
-  RecordingState,
-  SignupURL, STORAGE_KEY,
+	MOCKSI_MODIFICATIONS,
+	MOCKSI_RECORDING_STATE,
+	RecordingState,
+	STORAGE_KEY,
+	SignupURL,
 } from "./consts";
-import MocksiRollbar from "./MocksiRollbar";
 
 type DOMModificationsType = {
 	[querySelector: string]: { nextText: string; previousText: string };
 };
+interface ChromeStorage {
+	accessToken: string;
+	userId: string;
+	sessionId: string;
+	recordingState: RecordingState;
+	refreshToken: string;
+	email: string;
+}
 
 export const setRootPosition = (state: RecordingState) => {
 	const extensionRoot = document.getElementById("extension-root");
@@ -128,21 +137,21 @@ export const sendMessage = (
 		}
 	});
 
-export const getEmail = async(): Promise<string | null> =>  {
-  const value = await chrome.storage.local.get(STORAGE_KEY);
-  if (!value) {
-    window.open(SignupURL);
-    return null;  // Ensure a value is always returned
-  }
+export const getStorage = async (): Promise<ChromeStorage | null> => {
+	const value = await chrome.storage.local.get(STORAGE_KEY);
+	if (!value) {
+		window.open(SignupURL);
+		return null; // Ensure a value is always returned
+	}
 
-  const storedData = value[STORAGE_KEY] || "{}";
-  try {
-    const parsedData: { email: string } = JSON.parse(storedData);
-    return parsedData.email || null;
-  } catch (error) {
-    console.log("Error parsing data from storage: ", error);
-    MocksiRollbar.log("Error parsing email data, logging out.");
-    logout();
-    return null;
-  }
-}
+	const storedData = value[STORAGE_KEY] || "{}";
+	try {
+		const parsedData = JSON.parse(storedData);
+		return parsedData;
+	} catch (error) {
+		console.log("Error parsing data from storage: ", error);
+		MocksiRollbar.log("Error parsing storage data, logging out.");
+		logout();
+		return null;
+	}
+};

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -18,7 +18,7 @@ type DOMModificationsType = {
 	[querySelector: string]: { nextText: string; previousText: string };
 };
 
-export const setRootPosition = (state: RecordingState) => {
+export const setRootPosition = (state: RecordingState | null) => {
 	const extensionRoot = document.getElementById("extension-root");
 	if (extensionRoot) {
 		const bottom =


### PR DESCRIPTION
- Adds creator filter to get recordings endpoint
- Minor style fixes for recording list to fix `Create new demo` button to the bottom
- change user `RecordingState` if opens the extension with `RecordingState === EDITING`

https://github.com/Mocksi/HARlighter/assets/95246792/6b250882-c6fa-4e87-88c0-668089df6f71



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled retrieval of recordings based on user email and storage key.
  - Improved cancellation handling in the Create Demo form.
  - Enhanced button functionality in the Demo Item component based on URL and alterations.

- **Enhancements**
  - Consolidated timing configuration in Record Button component.

- **Bug Fixes**
  - Removed unnecessary import statement in content script.
  - Corrected CSS class assignments in Create Demo form for better alignment.

- **Chores**
  - Improved error logging and storage operations handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->