### PR TITLE
[NC]: Recoding state content fixes

### DIFF
--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -48,7 +48,13 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 					sendMessage("updateToPlayIcon");
 				}
 				setRootPosition(state);
-				root.render(<ContentApp isOpen={true} email={email || ""} />);
+				root.render(
+					<ContentApp
+						initialState={state ?? RecordingState.READY}
+						isOpen={true}
+						email={email || ""}
+					/>,
+				);
 			});
 		});
 	}


### PR DESCRIPTION
This PR adds some fixes to correctly handling the recording state, we need to store each state change to the chrome local storage to handle the different pop ups and the icon changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved state management consistency across components by refactoring the state logic in the application.
  - Removed redundant use of `useEffect` for initial state loading from Chrome storage.
  - Enhanced state update mechanism to ensure state is consistently saved and updated using a centralized `onChangeState` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->