### PR TITLE
[MOC-43][MOC-64]: Redirect user to demo url on play mode and undo-modifications fix

### DIFF
--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -1,7 +1,13 @@
 import MocksiRollbar from "./MocksiRollbar";
-import {STORAGE_KEY, SignupURL, WebSocketURL, MOCKSI_RECORDING_STATE, RecordingState} from "./consts";
+import {
+	MOCKSI_RECORDING_STATE,
+	RecordingState,
+	STORAGE_KEY,
+	SignupURL,
+	WebSocketURL,
+} from "./consts";
 import { apiCall } from "./networking";
-import {getAlterations, getEmail, loadAlterations, logout} from "./utils";
+import { getAlterations, getEmail, loadAlterations, logout } from "./utils";
 
 export interface Alteration {
 	selector: string;
@@ -316,10 +322,15 @@ function allEventHandler(
 }
 
 const setPlayMode = async (url?: string) => {
-  const [result] = await chrome.tabs.query({ active: true, lastFocusedWindow: true })
-  await chrome.tabs.create({url});
-  await chrome.action.setIcon({ path: "./public/pause-icon.png" });
-  await chrome.storage.local.set({ [MOCKSI_RECORDING_STATE]: RecordingState.HIDDEN });
+	const [result] = await chrome.tabs.query({
+		active: true,
+		lastFocusedWindow: true,
+	});
+	await chrome.tabs.create({ url });
+	await chrome.action.setIcon({ path: "./public/pause-icon.png" });
+	await chrome.storage.local.set({
+		[MOCKSI_RECORDING_STATE]: RecordingState.HIDDEN,
+	});
 };
 
 let currentTabId: number | undefined;
@@ -368,8 +379,8 @@ chrome.runtime.onMessage.addListener(
 		}
 
 		if (request.message === "playMode") {
-      const url: string = request.body?.url as string;
-      setPlayMode(url ?? "");
+			const url: string = request.body?.url as string;
+			setPlayMode(url ?? "");
 			return true;
 		}
 

--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -329,7 +329,7 @@ const setPlayMode = async (url?: string) => {
 	await chrome.tabs.create({ url });
 	await chrome.action.setIcon({ path: "./public/pause-icon.png" });
 	await chrome.storage.local.set({
-		[MOCKSI_RECORDING_STATE]: RecordingState.HIDDEN,
+		[MOCKSI_RECORDING_STATE]: RecordingState.PLAY,
 	});
 };
 

--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -1,7 +1,7 @@
 import MocksiRollbar from "./MocksiRollbar";
-import { STORAGE_KEY, SignupURL, WebSocketURL } from "./consts";
+import {STORAGE_KEY, SignupURL, WebSocketURL, MOCKSI_RECORDING_STATE, RecordingState} from "./consts";
 import { apiCall } from "./networking";
-import { getEmail, logout } from "./utils";
+import {getAlterations, getEmail, loadAlterations, logout} from "./utils";
 
 export interface Alteration {
 	selector: string;
@@ -315,6 +315,13 @@ function allEventHandler(
 	}
 }
 
+const setPlayMode = async (url?: string) => {
+  const [result] = await chrome.tabs.query({ active: true, lastFocusedWindow: true })
+  await chrome.tabs.create({url});
+  await chrome.action.setIcon({ path: "./public/pause-icon.png" });
+  await chrome.storage.local.set({ [MOCKSI_RECORDING_STATE]: RecordingState.HIDDEN });
+};
+
 let currentTabId: number | undefined;
 chrome.runtime.onMessage.addListener(
 	(
@@ -357,6 +364,12 @@ chrome.runtime.onMessage.addListener(
 
 		if (request.message === "resetIcon") {
 			chrome.action.setIcon({ path: "./public/mocksi-icon.png" });
+			return true;
+		}
+
+		if (request.message === "playMode") {
+      const url: string = request.body?.url as string;
+      setPlayMode(url ?? "");
 			return true;
 		}
 

--- a/apps/mocksi-lite/common/Button.tsx
+++ b/apps/mocksi-lite/common/Button.tsx
@@ -18,7 +18,7 @@ const getButtonStyles = (variant: Variant) => {
 		case Variant.primary:
 			return "bg-[#E8F3EC] border-[#E8F3EC] px-6";
 		case Variant.icon:
-			return "bg-[#E8F3EC] border-[#E8F3EC] p-3 max-h-[42px] h-[42px]";
+			return "bg-[#E8F3EC] border-[#E8F3EC] p-3 !max-h-[42px] !h-[42px]";
 		case Variant.secondary:
 			return "border-[#009875] px-6";
 		default:
@@ -35,9 +35,9 @@ const Button = ({
 	const styles = getButtonStyles(variant);
 	return (
 		<div
-			className={`border text-[#009875] w-fit min-h-[42px] rounded-full flex items-center justify-center ${
+			className={`border text-[#009875] w-fit !min-h-[42px] rounded-full flex items-center justify-center ${
 				disabled ? "cursor-not-allowed" : "cursor-pointer"
-			} ${styles} ${className}`}
+			} ${styles} ${className ?? ""}`}
 			onClick={!disabled ? onClick : undefined}
 			onKeyUp={(event) => {
 				event.key === "Enter" && onClick();

--- a/apps/mocksi-lite/content/ContentApp.tsx
+++ b/apps/mocksi-lite/content/ContentApp.tsx
@@ -50,12 +50,7 @@ function ShadowContentApp({ isOpen, email, initialState }: ContentProps) {
 			case RecordingState.EDITING:
 				return <EditToast state={state} onChangeState={onChangeState} />;
 			case RecordingState.PLAY:
-			case RecordingState.HIDDEN:
 				return <PlayToast onChangeState={onChangeState} close={closeDialog} />;
-			// case RecordingState.HIDDEN:
-			// 	return (
-			// 		<HiddenToast onChangeState={onChangeState} close={closeDialog} />
-			// 	);
 			default:
 				return (
 					<RecordingToast

--- a/apps/mocksi-lite/content/ContentApp.tsx
+++ b/apps/mocksi-lite/content/ContentApp.tsx
@@ -50,7 +50,7 @@ function ShadowContentApp({ isOpen, email, initialState }: ContentProps) {
 			case RecordingState.EDITING:
 				return <EditToast state={state} onChangeState={onChangeState} />;
 			case RecordingState.PLAY:
-      case RecordingState.HIDDEN:
+			case RecordingState.HIDDEN:
 				return <PlayToast onChangeState={onChangeState} close={closeDialog} />;
 			// case RecordingState.HIDDEN:
 			// 	return (

--- a/apps/mocksi-lite/content/ContentApp.tsx
+++ b/apps/mocksi-lite/content/ContentApp.tsx
@@ -50,11 +50,12 @@ function ShadowContentApp({ isOpen, email, initialState }: ContentProps) {
 			case RecordingState.EDITING:
 				return <EditToast state={state} onChangeState={onChangeState} />;
 			case RecordingState.PLAY:
+      case RecordingState.HIDDEN:
 				return <PlayToast onChangeState={onChangeState} close={closeDialog} />;
-			case RecordingState.HIDDEN:
-				return (
-					<HiddenToast onChangeState={onChangeState} close={closeDialog} />
-				);
+			// case RecordingState.HIDDEN:
+			// 	return (
+			// 		<HiddenToast onChangeState={onChangeState} close={closeDialog} />
+			// 	);
 			default:
 				return (
 					<RecordingToast

--- a/apps/mocksi-lite/content/Popup/CreateDemo/DemoItem.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/DemoItem.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../../consts";
 import editIcon from "../../../public/edit-icon.png";
 import playIcon from "../../../public/play-icon.png";
-import {loadAlterations, sendMessage} from "../../../utils";
+import { loadAlterations, sendMessage } from "../../../utils";
 import { setEditorMode } from "../../EditMode/editMode";
 
 interface DemoItemProps extends Recording {
@@ -23,7 +23,7 @@ const DemoItem = ({
 	alterations,
 	url,
 }: DemoItemProps) => {
-  const domain = new URL(url).hostname;
+	const domain = new URL(url).hostname;
 	const handleEdit = () => {
 		setEditorMode(true, uuid);
 		loadAlterations(alterations, true);
@@ -33,14 +33,14 @@ const DemoItem = ({
 	const handlePlay = async () => {
 		await chrome.storage.local.set({ [MOCKSI_ALTERATIONS]: alterations });
 		await chrome.storage.local.set({ [MOCKSI_RECORDING_ID]: uuid });
-    if (window.location.href === url) {
-      sendMessage("updateToPauseIcon");
-      loadAlterations(alterations, false);
-      setState(RecordingState.HIDDEN);
-    } else {
-      sendMessage("playMode", {url})
-    }
-  };
+		if (window.location.href === url) {
+			sendMessage("updateToPauseIcon");
+			loadAlterations(alterations, false);
+			setState(RecordingState.HIDDEN);
+		} else {
+			sendMessage("playMode", { url });
+		}
+	};
 
 	return (
 		<div className={"flex justify-between px-6"}>
@@ -66,10 +66,7 @@ const DemoItem = ({
 				<Button
 					variant={Variant.icon}
 					onClick={handlePlay}
-					disabled={
-						!alterations ||
-						!alterations.length
-					}
+					disabled={!alterations || !alterations.length}
 				>
 					<img src={playIcon} alt={"playIcon"} />
 				</Button>

--- a/apps/mocksi-lite/content/Popup/CreateDemo/DemoItem.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/DemoItem.tsx
@@ -31,12 +31,14 @@ const DemoItem = ({
 	};
 
 	const handlePlay = async () => {
-		await chrome.storage.local.set({ [MOCKSI_ALTERATIONS]: alterations });
-		await chrome.storage.local.set({ [MOCKSI_RECORDING_ID]: uuid });
+		await chrome.storage.local.set({
+			[MOCKSI_ALTERATIONS]: alterations,
+			[MOCKSI_RECORDING_ID]: uuid,
+		});
 		if (window.location.href === url) {
 			sendMessage("updateToPauseIcon");
 			loadAlterations(alterations, false);
-			setState(RecordingState.HIDDEN);
+			setState(RecordingState.PLAY);
 		} else {
 			sendMessage("playMode", { url });
 		}

--- a/apps/mocksi-lite/content/Popup/CreateDemo/DemoItem.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/DemoItem.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../../consts";
 import editIcon from "../../../public/edit-icon.png";
 import playIcon from "../../../public/play-icon.png";
-import { loadAlterations } from "../../../utils";
+import {loadAlterations, sendMessage} from "../../../utils";
 import { setEditorMode } from "../../EditMode/editMode";
 
 interface DemoItemProps extends Recording {
@@ -23,6 +23,7 @@ const DemoItem = ({
 	alterations,
 	url,
 }: DemoItemProps) => {
+  const domain = new URL(url).hostname;
 	const handleEdit = () => {
 		setEditorMode(true, uuid);
 		loadAlterations(alterations, true);
@@ -32,11 +33,15 @@ const DemoItem = ({
 	const handlePlay = async () => {
 		await chrome.storage.local.set({ [MOCKSI_ALTERATIONS]: alterations });
 		await chrome.storage.local.set({ [MOCKSI_RECORDING_ID]: uuid });
-		loadAlterations(alterations, false);
-		setState(RecordingState.PLAY);
-	};
+    if (window.location.href === url) {
+      sendMessage("updateToPauseIcon");
+      loadAlterations(alterations, false);
+      setState(RecordingState.HIDDEN);
+    } else {
+      sendMessage("playMode", {url})
+    }
+  };
 
-	const domain = new URL(url).hostname;
 	return (
 		<div className={"flex justify-between px-6"}>
 			<div className={"w-[200px]"}>
@@ -62,7 +67,6 @@ const DemoItem = ({
 					variant={Variant.icon}
 					onClick={handlePlay}
 					disabled={
-						!url.includes(window.location.hostname) ||
 						!alterations ||
 						!alterations.length
 					}

--- a/apps/mocksi-lite/content/Toast/HiddenToast.tsx
+++ b/apps/mocksi-lite/content/Toast/HiddenToast.tsx
@@ -4,11 +4,11 @@ import Button, { Variant } from "../../common/Button";
 import TextField from "../../common/TextField";
 import { RecordingState } from "../../consts";
 import {
-	getAlterations,
-	getRecordingsStorage,
-	loadAlterations,
-	loadRecordingId,
-	sendMessage,
+  getAlterations,
+  getRecordingsStorage,
+  loadAlterations,
+  loadRecordingId,
+  sendMessage, undoModifications,
 } from "../../utils";
 import { setEditorMode } from "../EditMode/editMode";
 import Divider from "../Popup/Divider";
@@ -42,6 +42,7 @@ const HiddenToast = ({ onChangeState, close }: HiddenToastProps) => {
 	};
 
 	const handleClose = () => {
+    undoModifications();
 		sendMessage("resetIcon");
 		onChangeState(RecordingState.CREATE);
 		close();

--- a/apps/mocksi-lite/content/Toast/HiddenToast.tsx
+++ b/apps/mocksi-lite/content/Toast/HiddenToast.tsx
@@ -4,11 +4,12 @@ import Button, { Variant } from "../../common/Button";
 import TextField from "../../common/TextField";
 import { RecordingState } from "../../consts";
 import {
-  getAlterations,
-  getRecordingsStorage,
-  loadAlterations,
-  loadRecordingId,
-  sendMessage, undoModifications,
+	getAlterations,
+	getRecordingsStorage,
+	loadAlterations,
+	loadRecordingId,
+	sendMessage,
+	undoModifications,
 } from "../../utils";
 import { setEditorMode } from "../EditMode/editMode";
 import Divider from "../Popup/Divider";
@@ -42,7 +43,7 @@ const HiddenToast = ({ onChangeState, close }: HiddenToastProps) => {
 	};
 
 	const handleClose = () => {
-    undoModifications();
+		undoModifications();
 		sendMessage("resetIcon");
 		onChangeState(RecordingState.CREATE);
 		close();

--- a/apps/mocksi-lite/content/Toast/PlayToast.tsx
+++ b/apps/mocksi-lite/content/Toast/PlayToast.tsx
@@ -19,7 +19,7 @@ interface PlayToastProps {
 }
 const PlayToast = ({ onChangeState, close }: PlayToastProps) => {
 	const handleEdit = async () => {
-    sendMessage("resetIcon");
+		sendMessage("resetIcon");
 		const alterations = await getAlterations();
 		loadAlterations(alterations, true);
 		setEditorMode(true);
@@ -31,11 +31,11 @@ const PlayToast = ({ onChangeState, close }: PlayToastProps) => {
 		close();
 	};
 
-  const handleStop = () => {
-    sendMessage("resetIcon");
-    undoModifications();
-    onChangeState(RecordingState.CREATE);
-  };
+	const handleStop = () => {
+		sendMessage("resetIcon");
+		undoModifications();
+		onChangeState(RecordingState.CREATE);
+	};
 
 	return (
 		<Toast className={"mb-7 gap-4 py-3 px-4"}>
@@ -50,10 +50,7 @@ const PlayToast = ({ onChangeState, close }: PlayToastProps) => {
 			</div>
 			<img src={labeledIcon} alt={"labeledIcon"} />
 			<div className={"flex gap-2"}>
-				<Button
-					variant={Variant.icon}
-					onClick={handleStop}
-				>
+				<Button variant={Variant.icon} onClick={handleStop}>
 					<img src={stopIcon} alt={"stopIcon"} />
 				</Button>
 				<Button variant={Variant.icon} onClick={handleEdit}>

--- a/apps/mocksi-lite/content/Toast/PlayToast.tsx
+++ b/apps/mocksi-lite/content/Toast/PlayToast.tsx
@@ -27,7 +27,7 @@ const PlayToast = ({ onChangeState, close }: PlayToastProps) => {
 	};
 	const handleHideToast = () => {
 		sendMessage("updateToPauseIcon");
-		onChangeState(RecordingState.HIDDEN);
+		onChangeState(RecordingState.PLAY);
 		close();
 	};
 

--- a/apps/mocksi-lite/content/Toast/PlayToast.tsx
+++ b/apps/mocksi-lite/content/Toast/PlayToast.tsx
@@ -19,6 +19,7 @@ interface PlayToastProps {
 }
 const PlayToast = ({ onChangeState, close }: PlayToastProps) => {
 	const handleEdit = async () => {
+    sendMessage("resetIcon");
 		const alterations = await getAlterations();
 		loadAlterations(alterations, true);
 		setEditorMode(true);
@@ -29,6 +30,13 @@ const PlayToast = ({ onChangeState, close }: PlayToastProps) => {
 		onChangeState(RecordingState.HIDDEN);
 		close();
 	};
+
+  const handleStop = () => {
+    sendMessage("resetIcon");
+    undoModifications();
+    onChangeState(RecordingState.CREATE);
+  };
+
 	return (
 		<Toast className={"mb-7 gap-4 py-3 px-4"}>
 			<div
@@ -44,10 +52,7 @@ const PlayToast = ({ onChangeState, close }: PlayToastProps) => {
 			<div className={"flex gap-2"}>
 				<Button
 					variant={Variant.icon}
-					onClick={() => {
-						undoModifications();
-						onChangeState(RecordingState.CREATE);
-					}}
+					onClick={handleStop}
 				>
 					<img src={stopIcon} alt={"stopIcon"} />
 				</Button>

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -1,11 +1,6 @@
 import ReactDOM from "react-dom/client";
-import {
-	MOCKSI_RECORDING_STATE,
-	RecordingState,
-	STORAGE_CHANGE_EVENT,
-	SignupURL,
-} from "../consts";
-import { getEmail, sendMessage, setRootPosition } from "../utils";
+import {MOCKSI_RECORDING_STATE, RecordingState, SignupURL, STORAGE_CHANGE_EVENT,} from "../consts";
+import {getAlterations, getEmail, loadAlterations, sendMessage, setRootPosition} from "../utils";
 import ContentApp from "./ContentApp";
 
 let root: ReactDOM.Root;
@@ -15,6 +10,17 @@ function initial() {
 		document.getElementById("extension-root") || document.createElement("div");
 	rootDiv.id = "extension-root";
 	document.body.appendChild(rootDiv);
+
+  chrome.storage.local.get([MOCKSI_RECORDING_STATE], (results) => {
+    const recordingState: RecordingState | null =
+      results[MOCKSI_RECORDING_STATE];
+    if (recordingState === RecordingState.HIDDEN) {
+      sendMessage("updateToPauseIcon")
+      getAlterations().then((alterations) => {
+        loadAlterations(alterations, false)
+      })
+    }
+  })
 }
 
 document.addEventListener("DOMContentLoaded", initial);

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -1,6 +1,17 @@
 import ReactDOM from "react-dom/client";
-import {MOCKSI_RECORDING_STATE, RecordingState, SignupURL, STORAGE_CHANGE_EVENT,} from "../consts";
-import {getAlterations, getEmail, loadAlterations, sendMessage, setRootPosition} from "../utils";
+import {
+	MOCKSI_RECORDING_STATE,
+	RecordingState,
+	STORAGE_CHANGE_EVENT,
+	SignupURL,
+} from "../consts";
+import {
+	getAlterations,
+	getEmail,
+	loadAlterations,
+	sendMessage,
+	setRootPosition,
+} from "../utils";
 import ContentApp from "./ContentApp";
 
 let root: ReactDOM.Root;
@@ -11,16 +22,16 @@ function initial() {
 	rootDiv.id = "extension-root";
 	document.body.appendChild(rootDiv);
 
-  chrome.storage.local.get([MOCKSI_RECORDING_STATE], (results) => {
-    const recordingState: RecordingState | null =
-      results[MOCKSI_RECORDING_STATE];
-    if (recordingState === RecordingState.HIDDEN) {
-      sendMessage("updateToPauseIcon")
-      getAlterations().then((alterations) => {
-        loadAlterations(alterations, false)
-      })
-    }
-  })
+	chrome.storage.local.get([MOCKSI_RECORDING_STATE], (results) => {
+		const recordingState: RecordingState | null =
+			results[MOCKSI_RECORDING_STATE];
+		if (recordingState === RecordingState.HIDDEN) {
+			sendMessage("updateToPauseIcon");
+			getAlterations().then((alterations) => {
+				loadAlterations(alterations, false);
+			});
+		}
+	});
 }
 
 document.addEventListener("DOMContentLoaded", initial);

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -15,6 +15,12 @@ import {
 import ContentApp from "./ContentApp";
 
 let root: ReactDOM.Root;
+async function handlePlayState() {
+  const alterations = await getAlterations();
+  if (alterations && alterations.length) {
+    loadAlterations(alterations, false);
+  }
+}
 
 function initial() {
 	const rootDiv =
@@ -22,16 +28,13 @@ function initial() {
 	rootDiv.id = "extension-root";
 	document.body.appendChild(rootDiv);
 
-	chrome.storage.local.get([MOCKSI_RECORDING_STATE], (results) => {
-		const recordingState: RecordingState | null =
-			results[MOCKSI_RECORDING_STATE];
-		if (recordingState === RecordingState.HIDDEN) {
-			sendMessage("updateToPauseIcon");
-			getAlterations().then((alterations) => {
-				loadAlterations(alterations, false);
-			});
-		}
-	});
+
+  chrome.storage.local.get([MOCKSI_RECORDING_STATE], (results) => {
+    const recordingState: RecordingState | null = results[MOCKSI_RECORDING_STATE];
+    if (recordingState === RecordingState.HIDDEN) {
+      handlePlayState();
+    }
+  });
 }
 
 document.addEventListener("DOMContentLoaded", initial);
@@ -62,7 +65,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 					});
 					state = RecordingState.CREATE;
 				}
-				if (recordingState === RecordingState.HIDDEN) {
+				if (recordingState === RecordingState.PLAY) {
 					sendMessage("updateToPlayIcon");
 				}
 				if (

--- a/apps/mocksi-lite/content/content.tsx
+++ b/apps/mocksi-lite/content/content.tsx
@@ -16,10 +16,10 @@ import ContentApp from "./ContentApp";
 
 let root: ReactDOM.Root;
 async function handlePlayState() {
-  const alterations = await getAlterations();
-  if (alterations && alterations.length) {
-    loadAlterations(alterations, false);
-  }
+	const alterations = await getAlterations();
+	if (alterations?.length) {
+		loadAlterations(alterations, false);
+	}
 }
 
 function initial() {
@@ -28,13 +28,13 @@ function initial() {
 	rootDiv.id = "extension-root";
 	document.body.appendChild(rootDiv);
 
-
-  chrome.storage.local.get([MOCKSI_RECORDING_STATE], (results) => {
-    const recordingState: RecordingState | null = results[MOCKSI_RECORDING_STATE];
-    if (recordingState === RecordingState.HIDDEN) {
-      handlePlayState();
-    }
-  });
+	chrome.storage.local.get([MOCKSI_RECORDING_STATE], (results) => {
+		const recordingState: RecordingState | null =
+			results[MOCKSI_RECORDING_STATE];
+		if (recordingState === RecordingState.HIDDEN) {
+			handlePlayState();
+		}
+	});
 }
 
 document.addEventListener("DOMContentLoaded", initial);

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -46,6 +46,7 @@ export const setRootPosition = (state: RecordingState | null) => {
 		const bottom =
 			state === RecordingState.READY ||
 			state === RecordingState.CREATE ||
+			state === RecordingState.HIDDEN ||
 			state === RecordingState.PLAY;
 		extensionRoot.className = bottom ? "bottom-extension" : "top-extension";
 	}


### PR DESCRIPTION
MOC-64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced play mode setting through updated use of `chrome.tabs` and `chrome.storage.local`.
  - Added new `handleStop` function in the `PlayToast` component for improved handling of stop actions.

- **Bug Fixes**
  - Resolved issues with button min-height constraints in `Button.tsx`.
  - Fixed rendering logic for `RecordingState.HIDDEN` in `ContentApp` to display the `PlayToast` component instead of `HiddenToast`.

- **Improvements**
  - Enhanced button styles and variants in `Button.tsx`.
  - Improved domain handling and conditional logic in `DemoItem.tsx`.
  - Refined root position settings in `utils.ts` for better state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->