### PR TITLE
[MOC-76] Double text on loading modifications.

### DIFF
--- a/apps/mocksi-lite/content/EditMode/actions.ts
+++ b/apps/mocksi-lite/content/EditMode/actions.ts
@@ -37,9 +37,8 @@ export function fragmentTextNode(
 	textNode: Node,
 	newText: string,
 ) {
-	const fragment = document.createDocumentFragment();
 	if (!textNode.nodeValue) {
-		return fragment;
+		return document.createDocumentFragment();
 	}
 	const baseFragment = document.createDocumentFragment();
 	let cursor = 0;

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -132,10 +132,13 @@ export const loadAlterations = (
 		getHighlighter(),
 		saveModification,
 	);
-	const modifiedElements: HTMLElement[] = []
+	const modifiedElements: HTMLElement[] = [];
 	for (const alteration of alterations) {
 		const { selector, dom_after, dom_before, type } = alteration;
-		if (domainModifications[selector]) continue; // this means if alteration has been applied.
+		// this means if alteration has been applied.
+		if (domainModifications[selector]) {
+			continue;
+		}
 		const elemToModify = getHTMLElementFromSelector(selector);
 		if (elemToModify) {
 			if (type === "text") {
@@ -144,12 +147,12 @@ export const loadAlterations = (
 					new RegExp(dom_before, "gi"),
 					sanitizeHtml(dom_after),
 					withHighlights,
-					modifiedElements
+					modifiedElements,
 				);
 			} else if (type === "image" && elemToModify instanceof HTMLImageElement) {
 				domManipulator.replaceImage(dom_before, dom_after);
 			}
-			modifiedElements.push(elemToModify as HTMLElement)
+			modifiedElements.push(elemToModify as HTMLElement);
 		}
 	}
 };

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -132,8 +132,10 @@ export const loadAlterations = (
 		getHighlighter(),
 		saveModification,
 	);
+	const modifiedElements: HTMLElement[] = []
 	for (const alteration of alterations) {
 		const { selector, dom_after, dom_before, type } = alteration;
+		if (domainModifications[selector]) continue; // this means if alteration has been applied.
 		const elemToModify = getHTMLElementFromSelector(selector);
 		if (elemToModify) {
 			if (type === "text") {
@@ -142,10 +144,12 @@ export const loadAlterations = (
 					new RegExp(dom_before, "gi"),
 					sanitizeHtml(dom_after),
 					withHighlights,
+					modifiedElements
 				);
 			} else if (type === "image" && elemToModify instanceof HTMLImageElement) {
 				domManipulator.replaceImage(dom_before, dom_after);
 			}
+			modifiedElements.push(elemToModify as HTMLElement)
 		}
 	}
 };

--- a/packages/dodom/receivers/DOMManipulator.ts
+++ b/packages/dodom/receivers/DOMManipulator.ts
@@ -66,23 +66,28 @@ export class DOMManipulator {
 		oldValueInPattern: RegExp,
 		newText: string,
 		highlightReplacements: boolean,
-		appliedReplacements: HTMLElement[] = []
+		appliedReplacements: HTMLElement[] = [],
 	) {
 		const fragmentsToHighlight: Node[] = [];
-		const replacementsToApply: { nodeToReplace: Node; replacement: Node }[] = [];
+		const replacementsToApply: { nodeToReplace: Node; replacement: Node }[] =
+			[];
 		// TO IMPROVE: Prevent iterating through already applied nodes!
 		// This is a bruteforce method to replace ALL nodes.
-		createTreeWalker(rootNode, (textNode) => {
-			fillReplacements(
-				textNode,
-				oldValueInPattern,
-				newText,
-				fragmentsToHighlight,
-				replacementsToApply,
-				this.fragmentTextNode,
-				this.saveModification,
-			);
-		}, appliedReplacements);
+		createTreeWalker(
+			rootNode,
+			(textNode) => {
+				fillReplacements(
+					textNode,
+					oldValueInPattern,
+					newText,
+					fragmentsToHighlight,
+					replacementsToApply,
+					this.fragmentTextNode,
+					this.saveModification,
+				);
+			},
+			appliedReplacements,
+		);
 		for (const { nodeToReplace, replacement } of replacementsToApply) {
 			if (nodeToReplace.parentElement == null) {
 				continue;
@@ -169,7 +174,7 @@ const cleanPattern = (pattern: RegExp) =>
 const createTreeWalker = (
 	rootElement: Node,
 	iterator: (textNode: Node) => void,
-	appliedReplacements: HTMLElement[] = []
+	appliedReplacements: HTMLElement[] = [],
 ) => {
 	const treeWalker = document.createTreeWalker(
 		rootElement,
@@ -177,7 +182,7 @@ const createTreeWalker = (
 		(node) => {
 			if (
 				node.parentElement instanceof HTMLScriptElement ||
-				node.parentElement instanceof HTMLStyleElement 
+				node.parentElement instanceof HTMLStyleElement
 			) {
 				return NodeFilter.FILTER_REJECT;
 			}
@@ -189,7 +194,8 @@ const createTreeWalker = (
 		textNode = treeWalker.currentNode;
 		// preventing processing already applied nodes and the empty ones.
 		if (
-			(textNode.parentElement && appliedReplacements.includes(textNode.parentElement)) ||
+			(textNode.parentElement &&
+				appliedReplacements.includes(textNode.parentElement)) ||
 			textNode.nodeValue === null ||
 			!textNode?.textContent?.trim()
 		) {

--- a/packages/dodom/receivers/DOMManipulator.ts
+++ b/packages/dodom/receivers/DOMManipulator.ts
@@ -71,8 +71,6 @@ export class DOMManipulator {
 		const fragmentsToHighlight: Node[] = [];
 		const replacementsToApply: { nodeToReplace: Node; replacement: Node }[] =
 			[];
-		// TO IMPROVE: Prevent iterating through already applied nodes!
-		// This is a bruteforce method to replace ALL nodes.
 		createTreeWalker(
 			rootNode,
 			(textNode) => {


### PR DESCRIPTION
Long story short, we were applying already modified nodes.


https://github.com/Mocksi/HARlighter/assets/67698200/80b658aa-ac32-429a-9901-69a0bf0ffa36



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved efficiency in text node manipulation by removing unnecessary document fragment creation when the text node has no value.
  - Enhanced the `loadAlterations` function to skip already applied changes and track modified elements for better performance.
  - Updated `createTreeWalker` in `DOMManipulator` to avoid processing already applied nodes and renamed variables for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->