### PR TITLE
[MOC-62][MOC-59] Recording state fixes for sign up and getting recordings for first page

### DIFF
--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -7,7 +7,13 @@ import {
 	WebSocketURL,
 } from "./consts";
 import { apiCall } from "./networking";
-import {getAlterations, getEmail, getRecordingsStorage, loadAlterations, logout} from "./utils";
+import {
+	getAlterations,
+	getEmail,
+	getRecordingsStorage,
+	loadAlterations,
+	logout,
+} from "./utils";
 
 export interface Alteration {
 	selector: string;
@@ -97,26 +103,26 @@ chrome.action.onClicked.addListener((activeTab) => {
 			onAttach.bind(null, currentTabId),
 		);
 		chrome.debugger.onDetach.addListener(debuggerDetachHandler);
-    getRecordingsStorage()
-      .then(recordings => {
-      if (recordings.length) {
-        chrome.tabs.sendMessage(currentTabId || 0, {
-          text: "clickedIcon",
-        });
-      } else {
-        getRecordings().then(() => {
-          chrome.tabs.sendMessage(currentTabId || 0, {
-            text: "clickedIcon",
-          });
-        });
-      }
-    })
-      .catch((err) => {
-        console.error(`Failed to get recordings: ${err}`);
-        chrome.tabs.sendMessage(currentTabId || 0, {
-          text: "clickedIcon",
-        });
-      })
+		getRecordingsStorage()
+			.then((recordings) => {
+				if (recordings.length) {
+					chrome.tabs.sendMessage(currentTabId || 0, {
+						text: "clickedIcon",
+					});
+				} else {
+					getRecordings().then(() => {
+						chrome.tabs.sendMessage(currentTabId || 0, {
+							text: "clickedIcon",
+						});
+					});
+				}
+			})
+			.catch((err) => {
+				console.error(`Failed to get recordings: ${err}`);
+				chrome.tabs.sendMessage(currentTabId || 0, {
+					text: "clickedIcon",
+				});
+			});
 
 		// biome-ignore lint/suspicious/noExplicitAny: error message
 	} catch (e: any) {
@@ -208,16 +214,16 @@ function updateDemo(data: Record<string, unknown>) {
 async function getRecordings() {
 	const email = await getEmail();
 	if (email) {
-    try {
-      const response = await apiCall(`recordings?creator=${email}`)
-      if (!response || response.length === 0) {
-        console.error("No recordings found or failed to fetch recordings.");
-        return;
-      }
-      await chrome.storage.local.set({ recordings: response });
-    } catch (err) {
-      console.error(`Failed to fetch recordings: ${err}`);
-    }
+		try {
+			const response = await apiCall(`recordings?creator=${email}`);
+			if (!response || response.length === 0) {
+				console.error("No recordings found or failed to fetch recordings.");
+				return;
+			}
+			await chrome.storage.local.set({ recordings: response });
+		} catch (err) {
+			console.error(`Failed to fetch recordings: ${err}`);
+		}
 	} else {
 		console.error("Email not found. Cannot fetch recordings.");
 	}

--- a/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
@@ -28,7 +28,10 @@ const CreateDemo = ({
 			try {
 				const newRecordings = await getRecordingsStorage();
 				if (newRecordings.length !== recordings.length) {
-					setRecordings(newRecordings);
+          const sortedRecordings = newRecordings.sort((a: Recording, b: Recording) =>
+            a.updated_timestamp > b.updated_timestamp ? -1 : 0,
+          );
+					setRecordings(sortedRecordings);
 					continueFetching = false; // Stop the loop if recordings have been updated
 				}
 			} catch (error) {
@@ -51,7 +54,7 @@ const CreateDemo = ({
 		<div className={"flex flex-1 flex-col h-[280px] overflow-x-scroll"}>
 			{recordings.length ? (
 				<div
-					className={"flex-1 flex flex-col py-8 overflow-y-scroll no-scrollbar"}
+					className={"flex-grow flex flex-col py-8 overflow-y-scroll no-scrollbar"}
 				>
 					{recordings
 						.filter((record) => record.url)

--- a/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
+++ b/apps/mocksi-lite/content/Popup/CreateDemo/index.tsx
@@ -28,9 +28,10 @@ const CreateDemo = ({
 			try {
 				const newRecordings = await getRecordingsStorage();
 				if (newRecordings.length !== recordings.length) {
-          const sortedRecordings = newRecordings.sort((a: Recording, b: Recording) =>
-            a.updated_timestamp > b.updated_timestamp ? -1 : 0,
-          );
+					const sortedRecordings = newRecordings.sort(
+						(a: Recording, b: Recording) =>
+							a.updated_timestamp > b.updated_timestamp ? -1 : 0,
+					);
 					setRecordings(sortedRecordings);
 					continueFetching = false; // Stop the loop if recordings have been updated
 				}
@@ -54,7 +55,9 @@ const CreateDemo = ({
 		<div className={"flex flex-1 flex-col h-[280px] overflow-x-scroll"}>
 			{recordings.length ? (
 				<div
-					className={"flex-grow flex flex-col py-8 overflow-y-scroll no-scrollbar"}
+					className={
+						"flex-grow flex flex-col py-8 overflow-y-scroll no-scrollbar"
+					}
 				>
 					{recordings
 						.filter((record) => record.url)

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -289,7 +289,7 @@ export const getRecordingsStorage = async (): Promise<Recording[]> => {
 	try {
 		const results = await chrome.storage.local.get(["recordings"]);
 		if (results.recordings) {
-			return results.recordings
+			return results.recordings;
 		}
 		return [];
 	} catch (err) {

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -289,7 +289,7 @@ export const getRecordingsStorage = async (): Promise<Recording[]> => {
 	try {
 		const results = await chrome.storage.local.get(["recordings"]);
 		if (results.recordings) {
-			return JSON.parse(results.recordings);
+			return results.recordings
 		}
 		return [];
 	} catch (err) {


### PR DESCRIPTION
This PR adds a bunch o fixes for recording states and signed or not users. Also adds a recording call when opening the extension, to check if we need to show the list of recordings as the first page or the record button.

https://github.com/Mocksi/HARlighter/assets/95246792/762dd263-3cf2-4061-87e4-406d5e864139



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved retrieval and management of recordings with updated logic.

- **Bug Fixes**
  - Enhanced handling of recordings retrieval to ensure correct storage and display.

- **Refactor**
  - Streamlined recording state management based on user login status.
  - Updated styling class names for better readability and maintenance.

- **Style**
  - Adjusted CSS class names for consistency and improved styling.

- **Performance**
  - Optimized recordings fetching by removing unnecessary data parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->