### PR TITLE
Add mocksi chat

### DIFF
--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -4,10 +4,10 @@ import {
 	RecordingState,
 	STORAGE_KEY,
 	SignupURL,
-	WebSocketURL,
 } from "./consts";
+import { initializeMckSocket, sendMckSocketMessage } from "./mckSocket";
 import { apiCall } from "./networking";
-import { getAlterations, getEmail, loadAlterations, logout } from "./utils";
+import { getEmail, getLastPageDom } from "./utils";
 
 export interface Alteration {
 	selector: string;
@@ -34,6 +34,7 @@ interface ChromeMessage {
 	status?: string;
 	tabId?: string;
 	body?: Record<string, unknown>;
+	detail?: string;
 }
 
 interface RequestInterception {
@@ -43,11 +44,17 @@ interface RequestInterception {
 	payload: string;
 }
 
+interface ChatResponse {
+	type: "ChatResponse";
+	chat_message: string;
+}
+
 interface ChromeMessageWithData extends ChromeMessage {
 	data: string;
 }
 
-const requestInterceptions: Map<string, RequestInterception> = new Map();
+const CHAT_UPDATED_EVENT = "chatUpdated";
+
 addEventListener("install", () => {
 	// TODO test if this works on other browsers
 	chrome.tabs.create({
@@ -100,7 +107,7 @@ chrome.action.onClicked.addListener((activeTab) => {
 		chrome.tabs.sendMessage(currentTabId || 0, {
 			text: "clickedIcon",
 		});
-		// biome-ignore lint/suspicious/noExplicitAny: error message
+		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 	} catch (e: any) {
 		console.error("Error attaching debugger", e);
 		if (e.message === "Cannot access a chrome:// URL") {
@@ -122,10 +129,10 @@ interface DataPayload {
 	currentURL?: string;
 }
 
-const credsJson = "";
+let currentTabId: number | undefined;
+const requestInterceptions: Map<string, RequestInterception> = new Map();
 
-// TODO: create a type for the request
-// biome-ignore lint/suspicious/noExplicitAny: this is hard to type
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 function sendData(request: Map<string, any>) {
 	if (!currentTabId) {
 		return;
@@ -150,11 +157,90 @@ function sendData(request: Map<string, any>) {
 			data.sessionID = sessionID;
 		}
 
-		// uri encode the data before sending to prevent
-		// problems with unicode data
-		const dataStr = JSON.stringify(data);
-		const encodedDataStr = encodeURIComponent(dataStr);
-		webSocket?.send(btoa(encodedDataStr));
+		sendMckSocketMessage(data);
+	});
+}
+
+export function handleMckSocketMessage(data: string) {
+	let command: RequestInterception | ChatResponse | null = null;
+	try {
+		const decodedBase64 = atob(data);
+		const decodedURL = decodeURIComponent(decodedBase64);
+		const parsed = JSON.parse(decodedURL);
+		command = parsed as RequestInterception | ChatResponse;
+	} catch (e) {
+		console.error("Error parsing MckSocket message", e);
+		return;
+	}
+
+	if (command?.type === "RequestInterception") {
+		const interceptDataEncoded = atob(command.payload);
+		const interceptData = decodeURIComponent(interceptDataEncoded);
+		const interception: RequestInterception = {
+			type: command.type,
+			url: command.url,
+			method: command.method,
+			payload: interceptData,
+		};
+		requestInterceptions.set(command.url, interception);
+		console.log("Will intercept request", command.url);
+
+		if (!currentTabId) {
+			return;
+		}
+
+		chrome.debugger.sendCommand(
+			{ tabId: currentTabId },
+			"Network.setRequestInterception",
+			{
+				patterns: [
+					{
+						urlPattern: command.url,
+						resourceType: "XHR",
+						interceptionStage: "HeadersReceived",
+					},
+				],
+			},
+			(response) => {
+				console.log("requested", response);
+			},
+		);
+		chrome.debugger.onEvent.addListener(allEventHandler);
+	}
+
+	if (command?.type === "ChatResponse") {
+		handleChatResponse(command as ChatResponse);
+	}
+
+	if (command?.type === "beginChat") {
+		console.log("TBD: beginChat");
+	}
+}
+
+function handleChatResponse(response: ChatResponse) {
+	chrome.storage.local.get([STORAGE_KEY], (result) => {
+		const messages = result[STORAGE_KEY] ? JSON.parse(result[STORAGE_KEY]) : [];
+		const newMessage = {
+			role: "assistant",
+			content: response.chat_message,
+		};
+		messages.push(newMessage);
+
+		chrome.storage.local.set(
+			{ [STORAGE_KEY]: JSON.stringify(messages) },
+			() => {
+				if (chrome.runtime.lastError) {
+					console.error("Error saving chat message:", chrome.runtime.lastError);
+				} else {
+					console.log("Chat message saved successfully");
+					chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+						if (tabs[0]?.id) {
+							chrome.tabs.sendMessage(tabs[0].id, { type: CHAT_UPDATED_EVENT });
+						}
+					});
+				}
+			},
+		);
 	});
 }
 
@@ -166,7 +252,6 @@ function onAttach(tabId: number) {
 function debuggerDetachHandler() {
 	requests.clear();
 }
-
 async function createDemo(body: Record<string, unknown>) {
 	const defaultBody = {
 		created_timestamp: new Date(),
@@ -211,15 +296,13 @@ async function getRecordings() {
 	}
 }
 
-// TODO: create a type for the params
-// biome-ignore lint/suspicious/noExplicitAny: also hard to type
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 const requests = new Map<string, Map<string, any>>();
 
 function allEventHandler(
 	debuggeeId: chrome.debugger.Debuggee,
 	message: string,
-	// TODO: create a type for the params
-	// biome-ignore lint/suspicious/noExplicitAny: params is a generic object
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 	params: any,
 ) {
 	if (currentTabId !== debuggeeId.tabId) {
@@ -228,8 +311,7 @@ function allEventHandler(
 
 	if (message === "Network.requestWillBeSent") {
 		if (params.request) {
-			// TODO: create a type for the detail
-			// biome-ignore lint/suspicious/noExplicitAny: same as above
+			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 			const detail = new Map<string, any>();
 			detail.set("request", params.request);
 			requests.set(params.requestId, detail);
@@ -277,7 +359,7 @@ function allEventHandler(
 				{
 					urls: [params.response.url],
 				},
-				// biome-ignore lint/suspicious/noExplicitAny: Reading from a generic object
+				// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 				(response: any) => {
 					if (response?.cookies) {
 						request.set("cookies", response.cookies);
@@ -333,7 +415,34 @@ const setPlayMode = async (url?: string) => {
 	});
 };
 
-let currentTabId: number | undefined;
+const handleRequestChat = async (message: string) => {
+	try {
+		const lastPageDom = await getLastPageDom();
+		const json_data = {
+			messageBody: {
+				messages: JSON.parse(message),
+				lastPageDom,
+			},
+		};
+		const payload = {
+			command: "requestChatTest",
+			type: "requestChatTest",
+			json_data: {
+				message: JSON.stringify({
+					type: "requestChat",
+					json_data: json_data,
+					user_id: "user123",
+					session_id: "session456",
+					event_timestamp: new Date().toISOString(),
+				}),
+			},
+		};
+		sendMckSocketMessage(payload);
+	} catch (error) {
+		console.error("Error handling requestChat:", error);
+	}
+};
+
 chrome.runtime.onMessage.addListener(
 	(
 		request: ChromeMessageWithData,
@@ -378,9 +487,40 @@ chrome.runtime.onMessage.addListener(
 			return true;
 		}
 
-		if (request.message === "playMode") {
-			const url: string = request.body?.url as string;
-			setPlayMode(url ?? "");
+		if (request.message === "Chat") {
+			return true;
+		}
+
+		if (
+			request.message === "requestChat" ||
+			request.message === "requestChatTest"
+		) {
+			try {
+				console.log("Requesting chat with message:", request.body);
+				const body = JSON.stringify(request.body) || "";
+				handleRequestChat(body);
+			} catch (error) {
+				console.log("Error handling requestChat:", error);
+			}
+
+			return true;
+		}
+
+		if (request.message === "ChatResponse") {
+			if (
+				request.body &&
+				typeof request.body === "object" &&
+				"chat_message" in request.body
+			) {
+				handleChatResponse(request.body as unknown as ChatResponse);
+				sendResponse({ message: request.message, status: "success" });
+			} else {
+				sendResponse({
+					message: request.message,
+					status: "error",
+					detail: "Invalid ChatResponse body",
+				});
+			}
 			return true;
 		}
 
@@ -389,93 +529,4 @@ chrome.runtime.onMessage.addListener(
 	},
 );
 
-let webSocket = new WebSocket(WebSocketURL);
-
-webSocket.onopen = () => {
-	keepAlive();
-};
-
-webSocket.onmessage = (event) => {
-	console.log(`websocket received message: ${event.data}`);
-	let command: RequestInterception | null = null;
-	try {
-		const parsed = JSON.parse(event.data);
-		command = parsed as RequestInterception;
-	} catch (e) {
-		console.error("Error parsing websocket message", e);
-		return;
-	}
-
-	if (command?.type === "RequestInterception") {
-		// data will be uri encoded to prevent issues with unicode
-		const interceptDataEncoded = atob(command.payload);
-		const interceptData = decodeURIComponent(interceptDataEncoded);
-		const interception: RequestInterception = {
-			type: command.type,
-			url: command.url,
-			method: command.method,
-			payload: interceptData,
-		};
-		requestInterceptions.set(command.url, interception);
-		console.log("Will intercept request", command.url);
-
-		if (!currentTabId) {
-			return;
-		}
-
-		chrome.debugger.sendCommand(
-			{ tabId: currentTabId },
-			"Network.setRequestInterception",
-			{
-				patterns: [
-					{
-						urlPattern: command.url,
-						resourceType: "XHR",
-						interceptionStage: "HeadersReceived",
-					},
-				],
-			},
-			(response) => {
-				console.log("requested", response);
-			},
-		);
-		chrome.debugger.onEvent.addListener(allEventHandler);
-	}
-};
-
-webSocket.onclose = () => {
-	console.log("websocket connection closed");
-	const reconnectInterval = 5000; // 5 seconds
-	// biome-ignore lint/suspicious/noExplicitAny: tried to add NodeJS.Timeout type but is breaking on prod build leaving as any for now.
-	let reconnectTimeout: any;
-
-	function reconnectWebSocket() {
-		if (reconnectTimeout) {
-			clearTimeout(reconnectTimeout);
-		}
-		reconnectTimeout = setTimeout(() => {
-			console.log("Reconnecting websocket...");
-			const oldWebSocket = webSocket;
-			webSocket = new WebSocket(WebSocketURL);
-			// FIXME: this is nasty, but it works
-			webSocket.onopen = oldWebSocket.onopen;
-			webSocket.onmessage = oldWebSocket.onmessage;
-			webSocket.onclose = oldWebSocket.onclose;
-		}, reconnectInterval);
-	}
-
-	reconnectWebSocket();
-};
-
-function keepAlive() {
-	const keepAliveIntervalId = setInterval(() => {
-		if (!webSocket) {
-			clearInterval(keepAliveIntervalId);
-		}
-		try {
-			webSocket.send("keepalive");
-		} catch (e) {
-			console.error("Error sending keepalive", e);
-		}
-	}, 5 * 1000);
-}
+initializeMckSocket();

--- a/apps/mocksi-lite/consts.ts
+++ b/apps/mocksi-lite/consts.ts
@@ -10,14 +10,18 @@ export const STORAGE_CHANGE_EVENT = "MOCKSI_STORAGE_CHANGE";
 export const MOCKSI_AUTH = "mocksi-auth";
 export const MOCKSI_HIGHLIGHTER_ID = "mocksi-highlighter";
 export const MOCKSI_IMAGE_REPLACER_ID = "mocksi-image-replacer";
+export const MOCKSI_LAST_PAGE_DOM = "mocksi-last-page-dom";
 
 export const MOCKSI_POPUP_LOCATION = "mocksi-popup-location";
-
+// FIXME: Move to an environment variable
 export const WebSocketURL = "wss://crowllectordb.onrender.com/ws";
+export const ChatWebSocketURL = "wss://crowllectordb.onrender.com/ws/chat";
+
 export const API_URL = "https://crowllectordb.onrender.com/api";
 // FIXME: Move to an environment variable
 export const SignupURL = "https://nest-auth-ts-merge.onrender.com";
 export const STORAGE_KEY = "mocksi-auth";
+export const CHAT_UPDATED_EVENT = "chatUpdated";
 
 export enum RecordingState {
 	UNAUTHORIZED = "UNAUTHORIZED",
@@ -28,6 +32,7 @@ export enum RecordingState {
 	EDITING = "EDITING",
 	PLAY = "PLAY",
 	HIDDEN = "HIDDEN",
+	CHAT = "CHAT",
 }
 
 export const popupTitle = "Tip & Tricks";

--- a/apps/mocksi-lite/content/ContentApp.tsx
+++ b/apps/mocksi-lite/content/ContentApp.tsx
@@ -1,8 +1,13 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import useShadow from "use-shadow-dom";
-import { MOCKSI_RECORDING_STATE, RecordingState } from "../consts";
-import { setRootPosition } from "../utils";
+import {
+	MOCKSI_LAST_PAGE_DOM,
+	MOCKSI_RECORDING_STATE,
+	RecordingState,
+} from "../consts";
+import { innerHTMLToJson, setRootPosition } from "../utils";
 import Popup from "./Popup";
+import ChatToast from "./Toast/ChatToast";
 import EditToast from "./Toast/EditToast";
 import HiddenToast from "./Toast/HiddenToast";
 import PlayToast from "./Toast/PlayToast";
@@ -19,6 +24,15 @@ function ShadowContentApp({ isOpen, email, initialState }: ContentProps) {
 	const [state, setState] = useState<RecordingState>(
 		initialState ?? RecordingState.UNAUTHORIZED,
 	);
+	useEffect(() => {
+		let dom_as_json = "";
+		try {
+			dom_as_json = innerHTMLToJson(document.body.innerHTML);
+		} catch (e) {
+			console.error("Error setting last page dom:", e);
+		}
+		chrome.storage.local.set({ [MOCKSI_LAST_PAGE_DOM]: dom_as_json });
+	});
 
 	const onChangeState = (newState: RecordingState) => {
 		chrome.storage.local
@@ -51,6 +65,8 @@ function ShadowContentApp({ isOpen, email, initialState }: ContentProps) {
 				return <EditToast state={state} onChangeState={onChangeState} />;
 			case RecordingState.PLAY:
 				return <PlayToast onChangeState={onChangeState} close={closeDialog} />;
+			case RecordingState.CHAT:
+				return <ChatToast onChangeState={setState} close={closeDialog} />;
 			default:
 				return (
 					<RecordingToast

--- a/apps/mocksi-lite/content/Popup/Footer.tsx
+++ b/apps/mocksi-lite/content/Popup/Footer.tsx
@@ -1,12 +1,43 @@
+import Button, { Variant } from "../../common/Button";
+import { RecordingState } from "../../consts";
 import { logout } from "../../utils";
 
-const Footer = ({
-	email,
-	close,
-}: { email: string | null; close: () => void }) => {
+interface FooterProps {
+	email: string | null;
+	close: () => void;
+	setState: (r: RecordingState) => void;
+}
+
+const Footer = ({ email, close, setState }: FooterProps) => {
+	const openChat = () => {
+		setState(RecordingState.CHAT);
+	};
 	return (
 		<div className={"h-[36px] flex items-center justify-end pr-3"}>
 			<div className={"text-[13px] text-[#5E5E5E] mr-2"}>{email}</div>
+			<Button
+				className="btn btn-square"
+				variant={Variant.secondary}
+				onClick={openChat}
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+					strokeWidth="1.5"
+					stroke="currentColor"
+					className="size-6"
+				>
+					<title>Beacon</title>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M9.75 3.104v5.714a2.25 2.25 0 0 1-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 0 1 4.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0 1 12 15a9.065 9.065 0 0 0-6.23-.693L5 14.5m14.8.8 1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0 1 12 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5"
+					/>
+				</svg>
+
+				<p>Open Mocksi AI</p>
+			</Button>
 			<div
 				className={"text-[13px] text-[#006C52] underline cursor-pointer"}
 				onClick={() => {

--- a/apps/mocksi-lite/content/Popup/index.tsx
+++ b/apps/mocksi-lite/content/Popup/index.tsx
@@ -38,7 +38,11 @@ const Popup = ({ close, setState, state, email }: PopupProps) => {
 		}
 	};
 
-	const onDragStop: DraggableEventHandler = (event, data) => {
+	const onDragStop: DraggableEventHandler = (
+		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+		event: any,
+		data: { x: number; y: number },
+	) => {
 		if (data.x === 0 || data.y === 0) {
 			return;
 		}
@@ -78,7 +82,7 @@ const Popup = ({ close, setState, state, email }: PopupProps) => {
 				{!createForm && (
 					<div>
 						<Divider />
-						<Footer close={close} email={email} />
+						<Footer close={close} email={email} setState={setState} />
 					</div>
 				)}
 			</div>

--- a/apps/mocksi-lite/content/Toast/ChatToast.tsx
+++ b/apps/mocksi-lite/content/Toast/ChatToast.tsx
@@ -1,0 +1,286 @@
+import React, { useCallback, useEffect, useState, useRef } from "react";
+import Toast from ".";
+import Button, { Variant } from "../../common/Button";
+import {
+	ChatWebSocketURL,
+	MOCKSI_RECORDING_STATE,
+	RecordingState,
+} from "../../consts";
+import closeIcon from "../../public/close-icon.png";
+import editIcon from "../../public/edit-icon.png";
+import mocksiLogo from "../../public/icon/icon48.png";
+import { getEmail, getLastPageDom, innerHTMLToJson } from "../../utils";
+
+interface Message {
+	role: "assistant" | "user";
+	content: string;
+}
+
+interface ResponseMessage {
+	message: {
+		content: string;
+	};
+}
+
+interface ChatToastProps {
+	close: () => void;
+	onChangeState: (r: RecordingState) => void;
+}
+
+interface DOMModification {
+	selector: string;
+	action: string;
+	content: string;
+}
+
+const ChatToast: React.FC<ChatToastProps> = React.memo(
+	({ onChangeState, close }) => {
+		const [messages, setMessages] = useState<Message[]>([]);
+		const [isTyping, setIsTyping] = useState<boolean>(false);
+		const [inputValue, setInputValue] = useState<string>("");
+		const [email, setEmail] = useState<string>("");
+		const [domData, setDomData] = useState<string>("");
+		const wsRef = useRef<WebSocket | null>(null);
+		const reconnectTimeoutRef = useRef<number | null>(null);
+
+		const connectWebSocket = useCallback(async () => {
+			if (wsRef.current?.readyState === WebSocket.OPEN) {
+				return;
+			}
+			const state = await chrome.storage.local.get([MOCKSI_RECORDING_STATE]);
+			if (!state || state[MOCKSI_RECORDING_STATE] !== RecordingState.CHAT) {
+				return;
+			}
+
+			wsRef.current = new WebSocket(ChatWebSocketURL);
+
+			wsRef.current.onopen = () => {
+				console.log("WebSocket connected");
+				if (reconnectTimeoutRef.current) {
+					clearTimeout(reconnectTimeoutRef.current);
+					reconnectTimeoutRef.current = null;
+				}
+				setIsTyping(false);
+			};
+
+			wsRef.current.onmessage = async (event) => {
+				let response: ResponseMessage | undefined;
+				try {
+					response = JSON.parse(event.data);
+				} catch (error) {
+					console.error("Error parsing JSON:", error);
+					setMessages((prevMessages) => [
+						...prevMessages,
+						{ role: "assistant", content: "Please try again." },
+					]);
+					return;
+				}
+
+				if (!response || !response.message || !response.message.content) {
+					console.error("Invalid response:", response);
+					setMessages((prevMessages) => [
+						...prevMessages,
+						{ role: "assistant", content: "Please try again." },
+					]);
+					return;
+				}
+
+				const data = JSON.parse(response.message.content);
+				// Continue processing the valid response...
+				if (!data || !data.description || !data.modifications) {
+					console.error("Invalid data:", data);
+					setMessages((prevMessages) => [
+						...prevMessages,
+						{ role: "assistant", content: "Please try again." },
+					]);
+					return;
+				}
+
+				setMessages((prevMessages) => [
+					...prevMessages,
+					{ role: "assistant", content: data.description },
+				]);
+
+				try {
+					await applyDOMModifications(data.modifications);
+					setIsTyping(false);
+					await new Promise((resolve) => window.setTimeout(resolve, 1000));
+					const updatedDomJson = innerHTMLToJson(document.body.innerHTML);
+					setDomData(updatedDomJson);
+				} catch (error) {
+					console.error("Error applying DOM modifications:", error);
+				}
+			};
+
+			wsRef.current.onerror = (error) => {
+				console.error("WebSocket error:", error);
+			};
+
+			wsRef.current.onclose = (event) => {
+				console.log("WebSocket closed. Attempting to reconnect...");
+				if (!reconnectTimeoutRef.current) {
+					reconnectTimeoutRef.current = window.setTimeout(() => {
+						connectWebSocket();
+					}, 3000); // Attempt to reconnect after 3 seconds
+				}
+			};
+		}, []);
+
+		useEffect(() => {
+			const dom_as_json = innerHTMLToJson(document.body.innerHTML);
+			setDomData(dom_as_json);
+
+			connectWebSocket();
+
+			getEmail().then((email) => {
+				setEmail(email || "");
+			});
+
+			return () => {
+				if (wsRef.current) {
+					wsRef.current.close();
+				}
+				if (reconnectTimeoutRef.current) {
+					clearTimeout(reconnectTimeoutRef.current);
+				}
+			};
+		}, [connectWebSocket]);
+
+		const applyDOMModifications = async (modifications: DOMModification[]) => {
+			for (const mod of modifications) {
+				const element = document.querySelector(mod.selector);
+				if (!element) {
+					console.warn(`Element not found for selector: ${mod.selector}`);
+					continue;
+				}
+
+				switch (mod.action) {
+					case "replace":
+						element.innerHTML = mod.content;
+						break;
+					case "append":
+						element.insertAdjacentHTML("beforeend", mod.content);
+						break;
+					case "prepend":
+						element.insertAdjacentHTML("afterbegin", mod.content);
+						break;
+					case "remove":
+						element.remove();
+						break;
+					default:
+						console.warn(`Unknown action: ${mod.action}`);
+				}
+
+				// Add a small delay between modifications to avoid overwhelming the browser
+				await new Promise((resolve) => window.setTimeout(resolve, 100));
+			}
+		};
+
+		const sendReply = useCallback(
+			(messageBody: { messages: Message[] }) => {
+				setIsTyping(true);
+				if (wsRef.current?.readyState === WebSocket.OPEN) {
+					const payload = JSON.stringify({ ...messageBody, domData, email });
+					console.log(`sending payload: ${payload}`);
+					wsRef.current.send(payload);
+				} else {
+					setIsTyping(true);
+					console.error("WebSocket is not open. Attempting to reconnect...");
+					connectWebSocket();
+				}
+			},
+			[email, domData, connectWebSocket],
+		);
+
+		const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+			e.preventDefault();
+			if (inputValue.trim()) {
+				const newMessage: Message = { role: "user", content: inputValue };
+				setMessages((prevMessages) => [...prevMessages, newMessage]);
+				setInputValue("");
+				sendReply({ messages: [...messages, newMessage] });
+			}
+		};
+
+		return (
+			<Toast
+				className="relative flex flex-col py-4 w-[800px] mr-6 mt-1 h-[900px]"
+				backgroundColor="bg-gray-300"
+			>
+				<div className="absolute top-0 left-0 m-2">
+					<Button
+						variant={Variant.secondary}
+						onClick={async () => {
+							await chrome.storage.local.set({
+								[MOCKSI_RECORDING_STATE]: RecordingState.CREATE,
+							});
+							close();
+						}}
+					>
+						<img src={closeIcon} alt="closeIcon" />
+					</Button>
+				</div>
+				<div className="flex flex-col justify-center items-center gap-6 mt-[75px] h-full">
+					<div className="flex-grow overflow-auto">
+						{messages.map((msg, i) => {
+							const chatKey = `chatKey${i}`;
+							const msgIcon = msg.role === "assistant" ? mocksiLogo : editIcon;
+							return (
+								<div
+									className={`chat ${
+										msg.role === "assistant" ? "chat-start" : "chat-end"
+									}`}
+									key={chatKey}
+								>
+									<div className="chat-image avatar">
+										<div className="w-10 rounded-full">
+											<img src={msgIcon} alt={`${msg.role} avatar`} />
+										</div>
+									</div>
+									<div className="chat-bubble bg-gray-200">{msg.content}</div>
+								</div>
+							);
+						})}
+					</div>
+
+					<form className="form-control items-center" onSubmit={handleSubmit}>
+						<div className="input-group max-w-full w-[500px] relative flex items-center">
+							{isTyping && (
+								<small className="absolute -top-5 left-0.5 animate-pulse">
+									MocksiAI is thinking...
+								</small>
+							)}
+
+							<input
+								type="text"
+								placeholder="Ask Mocksi a question..."
+								className="input input-bordered flex-grow mr-2.5 bg-white"
+								value={inputValue}
+								onChange={(e) => setInputValue(e.target.value)}
+								required
+								disabled={isTyping}
+							/>
+							<button
+								className={`btn btn-square ${isTyping ? "animate-pulse" : ""}`}
+								type="submit"
+								disabled={isTyping}
+							>
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									className="h-6 w-6"
+									fill="currentColor"
+									viewBox="0 0 16 16"
+								>
+									<title>Send</title>
+									<path d="M15.854.146a.5.5 0 0 1 .11.54l-5.819 14.547a.75.75 0 0 1-1.329.124l-3.178-4.995L.643 7.184a.75.75 0 0 1 .124-1.33L15.314.037a.5.5 0 0 1 .54.11ZM6.636 10.07l2.761 4.338L14.13 2.576 6.636 10.07Zm6.787-8.201L1.591 6.602l4.339 2.76 7.494-7.493Z" />
+								</svg>
+							</button>
+						</div>
+					</form>
+				</div>
+			</Toast>
+		);
+	},
+);
+
+export default ChatToast;

--- a/apps/mocksi-lite/content/Toast/index.tsx
+++ b/apps/mocksi-lite/content/Toast/index.tsx
@@ -3,12 +3,14 @@ import type { ReactNode } from "react";
 interface ToastProps {
 	children: ReactNode;
 	className?: string;
+	backgroundColor?: string;
 }
 
-const Toast = ({ className, children }: ToastProps) => {
+const Toast = ({ backgroundColor, className, children }: ToastProps) => {
+	const bgColor = backgroundColor ?? "bg-white";
 	return (
 		<div
-			className={`border border-solid border-grey/40 rounded bg-white flex flex-row items-center ${
+			className={`border border-solid border-grey/40 rounded ${bgColor} flex flex-row items-center ${
 				className ?? ""
 			}`}
 		>

--- a/apps/mocksi-lite/manifest.json
+++ b/apps/mocksi-lite/manifest.json
@@ -19,6 +19,9 @@
 			]
 		}
 	],
+	"content_security_policy": {
+		"extension_pages": "script-src 'self'; object-src 'self'"
+	},
 	"permissions": [
 		"activeTab",
 		"background",

--- a/apps/mocksi-lite/mckSocket.ts
+++ b/apps/mocksi-lite/mckSocket.ts
@@ -1,0 +1,151 @@
+import { WebSocketURL } from "./consts";
+
+let mckSocket: WebSocket;
+
+interface WebsocketResponse {
+	detail: string;
+	status: string;
+	type: string;
+	chat_message?: string;
+}
+
+export function initializeMckSocket() {
+	mckSocket = new WebSocket(WebSocketURL);
+
+	mckSocket.onopen = () => {
+		console.log("MckSocket connection opened");
+		keepAlive();
+	};
+
+	mckSocket.onmessage = (event) => {
+		console.log(`MckSocket received message: ${event.data}`);
+		handleMckSocketMessage(event.data);
+	};
+
+	mckSocket.onclose = () => {
+		console.log("MckSocket connection closed");
+		reconnectMckSocket();
+	};
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export function sendMckSocketMessage(message: any) {
+	if (mckSocket && mckSocket.readyState === WebSocket.OPEN) {
+		const jsonString = JSON.stringify(message);
+		const urlEncoded = encodeURIComponent(jsonString);
+		const base64Encoded = btoa(urlEncoded);
+		mckSocket.send(base64Encoded);
+	} else {
+		console.error("MckSocket is not open. Unable to send message.");
+	}
+}
+
+function reconnectMckSocket() {
+	const reconnectInterval = 5000; // 5 seconds
+
+	setTimeout(() => {
+		console.log("Reconnecting MckSocket...");
+		initializeMckSocket();
+	}, reconnectInterval);
+}
+
+function handleMckSocketMessage(data: string) {
+	try {
+		console.log("Raw WebSocket message:", data);
+
+		// Step 1: Decode Base64
+		const decodedBase64 = atob(data);
+		console.log("Decoded Base64 message:", decodedBase64);
+
+		// Step 2: Decode URL encoding
+		const decodedURL = decodeURIComponent(decodedBase64);
+		console.log("Decoded URL message:", decodedURL);
+
+		// Step 3: Parse JSON
+		const parsedData: WebsocketResponse = JSON.parse(decodedURL);
+		console.log("Parsed WebSocket message:", parsedData);
+
+		switch (parsedData.type) {
+			case "ChatResponse":
+				handleChatResponse(parsedData);
+				break;
+			case "RequestInterception":
+				handleRequestInterception(parsedData);
+				break;
+			default:
+				console.log("MCKReceived message:", parsedData.detail);
+		}
+	} catch (error) {
+		console.error("Error handling WebSocket message:", error);
+		console.error("Raw message that caused the error:", data);
+	}
+}
+function ensureAscii(input: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: <explanation>
+	return input.replace(/[^\x00-\x7F]/g, " ");
+}
+
+function removeAllPercent(input: string): string {
+	return input.replace(/%20/g, " ");
+}
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+function appendMessageToStorage(message: any) {
+	chrome.storage.local.get(["reply_messages"], (result) => {
+		const messages = result.reply_messages || [];
+		messages.push(message);
+		chrome.storage.local.set({ reply_messages: messages }, () => {
+			console.log("Message appended to storage");
+		});
+	});
+}
+
+function handleChatResponse(response: WebsocketResponse) {
+	if (!response.chat_message) {
+		console.error("ChatResponse does not contain chat_message");
+		return;
+	}
+	const withSpaces = ensureAscii(removeAllPercent(response.chat_message));
+	const output = decodeURIComponent(withSpaces);
+	const newMessage = {
+		role: "assistant",
+		content: output,
+	};
+	appendMessageToStorage(newMessage);
+}
+
+function handleRequestInterception(response: WebsocketResponse) {
+	if (response.detail) {
+		try {
+			const interceptionData = JSON.parse(response.detail);
+			console.log("Received request interception:", interceptionData);
+			// Handle the request interception data
+		} catch (error) {
+			console.error("Error parsing request interception data:", error);
+		}
+	}
+}
+
+let keepAliveIntervalId: number | null = null;
+
+function keepAlive() {
+	if (keepAliveIntervalId !== null) {
+		clearInterval(keepAliveIntervalId);
+	}
+
+	keepAliveIntervalId = setInterval(
+		() => {
+			if (!mckSocket) {
+				if (keepAliveIntervalId) {
+					clearInterval(keepAliveIntervalId);
+				}
+				return;
+			}
+			try {
+				sendMckSocketMessage("keepalive");
+			} catch (e) {
+				console.error("Error sending keepalive", e);
+			}
+		},
+		20 * 60 * 1000,
+	); // Set to 20 minutes
+}

--- a/apps/mocksi-lite/package.json
+++ b/apps/mocksi-lite/package.json
@@ -14,7 +14,8 @@
 		"react": "^18.1.0",
 		"react-dom": "^18.1.0",
 		"tailwindcss": "^3.4.1",
-		"typescript": "5.3.3"
+		"typescript": "5.3.3",
+		"xslt-processor": "^3.0.0"
 	},
 	"scripts": {
 		"dev": "extension dev",

--- a/packages/dodom/tests/receivers/DOMManipulator.test.ts
+++ b/packages/dodom/tests/receivers/DOMManipulator.test.ts
@@ -5,6 +5,7 @@ import { replaceFirstLetterCase } from "../../receivers/DOMManipulator";
 const mockFragmentTextNode = vi.fn();
 const mockContentHighlighter = {
 	highlightNode: vi.fn(),
+	removeHighlightNode: vi.fn(),
 };
 const mockSaveModification = vi.fn();
 global.MutationObserver = vi.fn(function MutationObserver(callback) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       typescript:
         specifier: 5.3.3
         version: 5.3.3
+      xslt-processor:
+        specifier: ^3.0.0
+        version: 3.0.0
 
   packages/dodom:
     dependencies:
@@ -3568,6 +3571,10 @@ packages:
     resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
     engines: {node: '>= 0.4'}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   header-case@1.0.1:
     resolution: {integrity: sha512-i0q9mkOeSuhXw6bGgiQCCBgY/jlZuV/7dZXyZ9c6LcBrqwvT8eT719E9uxE5LiZftdl+z81Ugbg/VvXV4OJOeQ==}
 
@@ -4363,6 +4370,15 @@ packages:
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
+  node-fetch@2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -5713,6 +5729,9 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@5.0.0:
     resolution: {integrity: sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==}
     engines: {node: '>=18'}
@@ -6067,6 +6086,9 @@ packages:
   webextension-polyfill@0.8.0:
     resolution: {integrity: sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -6221,6 +6243,9 @@ packages:
     resolution: {integrity: sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==}
     engines: {node: '>=18'}
 
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   when@3.7.7:
     resolution: {integrity: sha512-9lFZp/KHoqH6bPKjbWqa+3Dg/K/r2v0X/3/G2x4DBGchVS2QX2VXL3cZV994WQVnTM1/PD71Az25nAzryEUugw==}
 
@@ -6313,6 +6338,9 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xslt-processor@3.0.0:
+    resolution: {integrity: sha512-gqYOwg8ZZ8e0iGxR/C41Qc4m9pJoQonrxGzuUoSLiX5Io0qGzQxyh1XXAq2kbHv8hq38QkfrhDWaBdwwLi8+kQ==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -10291,6 +10319,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  he@1.2.0: {}
+
   header-case@1.0.1:
     dependencies:
       no-case: 2.3.2
@@ -11057,6 +11087,10 @@ snapshots:
       lower-case: 1.1.4
 
   node-abort-controller@3.1.1: {}
+
+  node-fetch@2.6.7:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-forge@1.3.1: {}
 
@@ -12624,6 +12658,8 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
+  tr46@0.0.3: {}
+
   tr46@5.0.0:
     dependencies:
       punycode: 2.3.1
@@ -12960,6 +12996,8 @@ snapshots:
 
   webextension-polyfill@0.8.0: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@7.0.0: {}
 
   webpack-browser-extension-common-errors@1.1.1(webpack@5.89.0):
@@ -13203,6 +13241,11 @@ snapshots:
       tr46: 5.0.0
       webidl-conversions: 7.0.0
 
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   when@3.7.7: {}
 
   which-boxed-primitive@1.0.2:
@@ -13306,6 +13349,13 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   xmlchars@2.2.0: {}
+
+  xslt-processor@3.0.0:
+    dependencies:
+      he: 1.2.0
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
- **add chattoast**
- **Refactor to add WebSocketBuilder**
- **enable closing chat**
- **Revert "Refactor to add WebSocketBuilder"**
- **send chat request to websocket**
- **[NC]: Window redirection to sign up when user is logged out (#74)**
- **[NC]: Recoding state content fixes (#75)**
- **[NC]: Recoding position fix after recoding state change (#76)**
- **[MOC-63] Re edit feature (#77)**
- **ensure only one keepAlive timer is running**
- **prep ChatToast for wiring**
- **hackiest stuff ever**
- **enable sending arbitrary prompts via the chat**
- **lint**
- **use onrender**
- **add type for tests**
- **refactor to use an independent websocket**
- **working version**
- **fix prompts**
- **get the dom directly**
- **use XSLT only**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced WebSocket communication for real-time chat functionality.
	- Added a chat interface integrated within toast notifications.
	- Implemented highlight visibility management for better UI interaction.
- **Enhancements**
	- Improved state management and storage handling in various components.
	- Updated authentication and logout processes for improved user experience.
	- Enhanced editing functionalities with additional parameters for submission and cancellation.
- **Bug Fixes**
	- Improved error handling in message processing.
	- Updated rendering logic to handle unauthorized states effectively.
- **Dependencies**
	- Added a new dependency: `xslt-processor` version `^3.0.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->