### PR TITLE
added css to block pointer events

### DIFF
--- a/apps/mocksi-lite/content/EditMode/editMode.ts
+++ b/apps/mocksi-lite/content/EditMode/editMode.ts
@@ -17,18 +17,18 @@ export const setEditorMode = async (turnOn: boolean, recordingId?: string) => {
 
 const setupEditor = async (recordingId?: string) => {
 	sendMessage("attachDebugger");
-		if (recordingId) {
-			await chrome.storage.local.set({ [MOCKSI_RECORDING_ID]: recordingId });
-		}
+	if (recordingId) {
+		await chrome.storage.local.set({ [MOCKSI_RECORDING_ID]: recordingId });
+	}
 
-		// blockClickableElements();
-		console.log('injecting styles');
-		injectStylesToBlockEvents();
+	// blockClickableElements();
+	console.log("injecting styles");
+	injectStylesToBlockEvents();
 
-		document.body.addEventListener("dblclick", onDoubleClickText);
+	document.body.addEventListener("dblclick", onDoubleClickText);
 
-		return;
-}
+	return;
+};
 const teardownEditor = async (recordingId?: string) => {
 	if (recordingId) {
 		await persistModifications(recordingId);
@@ -40,12 +40,12 @@ const teardownEditor = async (recordingId?: string) => {
 	document.body.removeEventListener("dblclick", onDoubleClickText);
 	removeStylesToBlockEvents();
 	cancelEditWithoutChanges(document.getElementById("mocksiSelectedText"));
-}
+};
 
 function onDoubleClickText(event: MouseEvent) {
 	// @ts-ignore MouseEvent typing seems incomplete
 	const nodeName = event?.toElement?.nodeName;
-	console.log('we double clicked on', event.target)
+	console.log("we double clicked on", event.target);
 	if (nodeName === "IMG") {
 		const targetedElement: HTMLImageElement = event.target as HTMLImageElement;
 		console.log("Image clicked", targetedElement.alt);
@@ -240,21 +240,19 @@ const injectStylesToBlockEvents = () => {
 	const style = document.createElement("style");
 	style.id = "mocksi-block-events-style";
 	style.innerHTML = `
-		a, button, img {
+		a, button, img, input, textarea, select, option, checkbox, radio, label {
 			pointer-events: none;
 		}
 	`;
 	document.head.appendChild(style);
-}
+};
 
 const removeStylesToBlockEvents = () => {
 	const style = document.getElementById("mocksi-block-events-style");
 	if (style) {
 		style.remove();
 	}
-}
-
-
+};
 
 const restoreNodes = () => {
 	if (blockedNodes.length > 0) {

--- a/apps/mocksi-lite/content/EditMode/editMode.ts
+++ b/apps/mocksi-lite/content/EditMode/editMode.ts
@@ -36,7 +36,7 @@ export const setEditorMode = async (turnOn: boolean, recordingId?: string) => {
 
 const setupEditor = async (recordingId?: string) => {
 	sendMessage("attachDebugger");
-	
+
 	if (recordingId) {
 		await chrome.storage.local.set({ [MOCKSI_RECORDING_ID]: recordingId });
 		observeUrlChange(() => {


### PR DESCRIPTION
POC for blocking out events and "freezing page" by using CSS to disable pointer events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced editor mode functionality with improved setup and teardown processes.
	- Introduced style management to prevent user interactions during editing.

- **Bug Fixes**
	- Improved cleanup process when exiting editor mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->