### PR TITLE
use observer to clear highlights when navigation changes

### DIFF
--- a/apps/mocksi-lite/content/EditMode/editMode.ts
+++ b/apps/mocksi-lite/content/EditMode/editMode.ts
@@ -9,21 +9,21 @@ import { decorate } from "./decorator";
 import { getHighlighter } from "./highlighter";
 
 const observeUrlChange = (onChange: () => void) => {
-  let oldHref = document.location.href;
-  const body = document.querySelector("body");
+	let oldHref = document.location.href;
+	const body = document.querySelector("body");
 
 	if (!body) {
 		console.error("body not found");
 		return;
 	}
 
-  const observer = new MutationObserver(mutations => {
-    if (oldHref !== document.location.href) {
-      oldHref = document.location.href;
-      onChange()
-    }
-  });
-  observer.observe(body, { childList: true, subtree: true });
+	const observer = new MutationObserver((mutations) => {
+		if (oldHref !== document.location.href) {
+			oldHref = document.location.href;
+			onChange();
+		}
+	});
+	observer.observe(body, { childList: true, subtree: true });
 };
 
 export const setEditorMode = async (turnOn: boolean, recordingId?: string) => {
@@ -36,7 +36,7 @@ export const setEditorMode = async (turnOn: boolean, recordingId?: string) => {
 		blockClickableElements();
 		observeUrlChange(() => {
 			console.log("URL changed, turning off edit mode");
-			const highlighter = getHighlighter()
+			const highlighter = getHighlighter();
 			highlighter.removeHighlightNodes();
 		});
 		document.body.addEventListener("dblclick", onDoubleClickText);

--- a/apps/mocksi-lite/content/EditMode/editMode.ts
+++ b/apps/mocksi-lite/content/EditMode/editMode.ts
@@ -6,6 +6,25 @@ import {
 } from "../../utils";
 import { applyImageChanges, cancelEditWithoutChanges } from "./actions";
 import { decorate } from "./decorator";
+import { getHighlighter } from "./highlighter";
+
+const observeUrlChange = (onChange: () => void) => {
+  let oldHref = document.location.href;
+  const body = document.querySelector("body");
+
+	if (!body) {
+		console.error("body not found");
+		return;
+	}
+
+  const observer = new MutationObserver(mutations => {
+    if (oldHref !== document.location.href) {
+      oldHref = document.location.href;
+      onChange()
+    }
+  });
+  observer.observe(body, { childList: true, subtree: true });
+};
 
 export const setEditorMode = async (turnOn: boolean, recordingId?: string) => {
 	if (turnOn) {
@@ -15,6 +34,11 @@ export const setEditorMode = async (turnOn: boolean, recordingId?: string) => {
 		}
 
 		blockClickableElements();
+		observeUrlChange(() => {
+			console.log("URL changed, turning off edit mode");
+			const highlighter = getHighlighter()
+			highlighter.removeHighlightNodes();
+		});
 		document.body.addEventListener("dblclick", onDoubleClickText);
 		return;
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced editing mode to automatically turn off when the URL changes, improving user experience and preventing editing conflicts. 
	- Introduced a URL observation feature that monitors changes and triggers necessary updates in edit mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->