### PR TITLE
MOC-116 editing fixes

### DIFF
--- a/apps/mocksi-lite/content/EditMode/editMode.ts
+++ b/apps/mocksi-lite/content/EditMode/editMode.ts
@@ -255,8 +255,8 @@ const removeStylesToBlockEvents = () => {
 
 export const applyReadOnlyMode = () => {
 	injectStylesToBlockEvents();
-}
+};
 
 export const removeReadOnlyMode = () => {
 	removeStylesToBlockEvents();
-}
+};

--- a/apps/mocksi-lite/content/EditMode/editMode.ts
+++ b/apps/mocksi-lite/content/EditMode/editMode.ts
@@ -252,3 +252,11 @@ const removeStylesToBlockEvents = () => {
 		style.remove();
 	}
 };
+
+export const applyReadOnlyMode = () => {
+	injectStylesToBlockEvents();
+}
+
+export const removeReadOnlyMode = () => {
+	removeStylesToBlockEvents();
+}

--- a/apps/mocksi-lite/content/EditMode/editMode.ts
+++ b/apps/mocksi-lite/content/EditMode/editMode.ts
@@ -290,6 +290,7 @@ function applyEditor(
 	if (selectedRange === null || selectedRange.anchorNode === null) {
 		return;
 	}
+
 	if (selectedRange.anchorNode === selectedRange.focusNode) {
 		for (const node of targetedElement.childNodes) {
 			if (
@@ -298,7 +299,7 @@ function applyEditor(
 			) {
 				targetedElement.replaceChild(
 					decorateTextTag(
-						selectedRange.anchorNode?.textContent || "",
+						selectedRange.anchorNode.textContent || "",
 						targetedElement.clientWidth?.toString() || "",
 						shiftMode,
 						selectedRange.getRangeAt(0),

--- a/apps/mocksi-lite/content/Toast/EditToast.tsx
+++ b/apps/mocksi-lite/content/Toast/EditToast.tsx
@@ -3,7 +3,7 @@ import TextField from "../../common/TextField";
 import closeIcon from "../../public/close-icon.png";
 import { loadRecordingId, recordingLabel } from "../../utils";
 import { AppEvent, AppStateContext } from "../AppStateContext";
-import { setEditorMode } from "../EditMode/editMode";
+import { applyReadOnlyMode, removeReadOnlyMode, setEditorMode } from "../EditMode/editMode";
 import { getHighlighter } from "../EditMode/highlighter";
 import IframeWrapper from "../IframeWrapper";
 import Toast from "./index";
@@ -12,6 +12,7 @@ const EditToast = () => {
 	const { state, dispatch } = useContext(AppStateContext);
 
 	const [areChangesHighlighted, setAreChangesHighlighted] = useState(true);
+	const [isReadOnlyModeEnabled, setIsReadOnlyModeEnabled] = useState(true);
 
 	const ContentHighlighter = getHighlighter();
 
@@ -21,6 +22,20 @@ const EditToast = () => {
 			return !prevValue;
 		});
 	};
+
+	const onReadOnlyChecked = () => {
+		setIsReadOnlyModeEnabled((prevValue) => {
+			const newVal = !prevValue;
+
+			if (newVal) {
+				applyReadOnlyMode();
+			} else {
+				removeReadOnlyMode();
+			}
+
+			return newVal;
+		});
+	}
 
 	const handleSave = async () => {
 		const recordingId = await loadRecordingId();
@@ -69,6 +84,18 @@ const EditToast = () => {
 						/>
 						<div className="mw-text-[13px] leading-[15px]">
 							Highlight All Previous Changes
+						</div>
+					</div>
+
+					<div className="mw-flex mw-gap-2 mw-items-center">
+						<input
+							checked={isReadOnlyModeEnabled}
+							onChange={() => onReadOnlyChecked()}
+							type="checkbox"
+							className="mw-h-5 mw-w-5 !rounded-lg"
+						/>
+						<div className="mw-text-[13px] leading-[15px]">
+							{isReadOnlyModeEnabled ? "Disable" : "Enable"} Read-Only Mode
 						</div>
 					</div>
 				</div>

--- a/apps/mocksi-lite/content/Toast/EditToast.tsx
+++ b/apps/mocksi-lite/content/Toast/EditToast.tsx
@@ -3,7 +3,11 @@ import TextField from "../../common/TextField";
 import closeIcon from "../../public/close-icon.png";
 import { loadRecordingId, recordingLabel } from "../../utils";
 import { AppEvent, AppStateContext } from "../AppStateContext";
-import { applyReadOnlyMode, removeReadOnlyMode, setEditorMode } from "../EditMode/editMode";
+import {
+	applyReadOnlyMode,
+	removeReadOnlyMode,
+	setEditorMode,
+} from "../EditMode/editMode";
 import { getHighlighter } from "../EditMode/highlighter";
 import IframeWrapper from "../IframeWrapper";
 import Toast from "./index";
@@ -35,7 +39,7 @@ const EditToast = () => {
 
 			return newVal;
 		});
-	}
+	};
 
 	const handleSave = async () => {
 		const recordingId = await loadRecordingId();


### PR DESCRIPTION
**Adds**
1. Ability to toggle read only on and off
2. Ability to edit elements that were previously blocked (ie. deeply nested elements).
3. When elements are edited they keep their original structure and styling

https://github.com/user-attachments/assets/4ce35a02-717f-4967-a781-ba3159e7d033



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a read-only mode toggle in the EditToast component for enhanced user control.
	- Added visual feedback for the read-only state with a dynamic checkbox.

- **Bug Fixes**
	- Improved clarity in URL change handling when transitioning out of edit mode.

- **Refactor**
	- Streamlined double-click handling and removed unused code to enhance performance and simplify the editor's functionality.

- **Chores**
	- Improved event listener management for consistent functionality during editing sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->