### PR TITLE
Fix MOC-128 by adding a custom css property check

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -44,5 +44,3 @@ jobs:
         run: pnpm --prefix packages/dodom exec vitest run
       - name: Run reactor tests
         run: pnpm --prefix packages/reactor exec vitest run
-      - name: Run mocksi-lite tests
-        run: pnpm --prefix apps/mocksi-lite exec vitest run

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -44,3 +44,5 @@ jobs:
         run: pnpm --prefix packages/dodom exec vitest run
       - name: Run reactor tests
         run: pnpm --prefix packages/reactor exec vitest run
+      - name: Run mocksi-lite tests
+        run: pnpm --prefix apps/mocksi-lite exec vitest run

--- a/apps/mocksi-lite/content/ContentApp.tsx
+++ b/apps/mocksi-lite/content/ContentApp.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useState } from "react";
 import useShadow from "use-shadow-dom";
 import type { Recording } from "../background";
 import { MOCKSI_LAST_PAGE_DOM } from "../consts";
-import { innerHTMLToJson, logout, setRootPosition } from "../utils";
+import { extractStyles, innerHTMLToJson, logout } from "../utils";
 import {
 	AppEvent,
 	AppState,
@@ -94,41 +94,17 @@ function ShadowContentApp({ isOpen, email }: ContentProps) {
 	return renderContent();
 }
 
-const extractStyles = (): string => {
-	let styles = "";
-	const styleSheets = Array.from(document.styleSheets) as CSSStyleSheet[];
-	// FIXME: This is a hack to prevent styles leaking from the page being edited
-	const lastFiveStyles = styleSheets.slice(-5);
-
-	for (const sheet of lastFiveStyles) {
-		// Skip external stylesheets
-		if (sheet.href) {
-			continue;
-		}
-		try {
-			if (sheet.cssRules) {
-				const cssRules = Array.from(sheet.cssRules) as CSSRule[];
-				for (const rule of cssRules) {
-					styles += rule.cssText;
-				}
-			}
-		} catch (e) {
-			console.error("Error accessing stylesheet:", e);
-		}
-	}
-
-	return styles;
-};
-
 export default function ContentApp({
 	isOpen,
 	email,
 	initialState,
 }: ContentProps) {
-	const styles = extractStyles();
+	const styles = extractStyles(document.styleSheets);
 	return useShadow(
 		<AppStateProvider initialRecordings={initialState?.recordings}>
-			<ShadowContentApp isOpen={isOpen} email={email} />
+			<div className="mcksi-frame-include">
+				<ShadowContentApp isOpen={isOpen} email={email} />
+			</div>
 		</AppStateProvider>,
 		[],
 		{

--- a/apps/mocksi-lite/content/IframeWrapper.tsx
+++ b/apps/mocksi-lite/content/IframeWrapper.tsx
@@ -1,6 +1,7 @@
 // biome-ignore lint/style/useImportType: types are messy
 import { ReactNode, useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
+import { extractStyles } from "../utils";
 
 interface IframeWrapperProps {
 	children: ReactNode;
@@ -9,32 +10,6 @@ interface IframeWrapperProps {
 	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 	[x: string]: any;
 }
-
-const extractStyles = (): string => {
-	let styles = "";
-	const styleSheets = Array.from(document.styleSheets) as CSSStyleSheet[];
-	// FIXME: This is a hack to prevent styles leaking from the page being edited
-	const lastFourStyles = styleSheets.slice(-4);
-
-	for (const sheet of lastFourStyles) {
-		try {
-			// Skip external stylesheets
-			if (sheet.href) {
-				continue;
-			}
-			if (sheet.cssRules) {
-				const cssRules = Array.from(sheet.cssRules) as CSSRule[];
-				for (const rule of cssRules) {
-					styles += rule.cssText;
-				}
-			}
-		} catch (e) {
-			console.error("Error accessing stylesheet:", e);
-		}
-	}
-
-	return styles;
-};
 
 const IframeWrapper = ({
 	children,
@@ -57,7 +32,7 @@ const IframeWrapper = ({
 			return;
 		}
 
-		let baseStyles = extractStyles();
+		let baseStyles = extractStyles(document.styleSheets);
 		// Append component styles
 		if (styles) {
 			baseStyles += styles;

--- a/apps/mocksi-lite/content/base.css
+++ b/apps/mocksi-lite/content/base.css
@@ -11,4 +11,8 @@
     -ms-overflow-style: none;  /* IE and Edge */
     scrollbar-width: none;  /* Firefox */
   }
+  /* Add the custom utility */
+  .mcksi-frame-include {
+    --mcksi-frame-include: true;
+  }
 }

--- a/apps/mocksi-lite/content/content.css
+++ b/apps/mocksi-lite/content/content.css
@@ -15,3 +15,7 @@
 .bottom-extension {
   bottom: 0;
 }
+
+.mcksi-frame-include {
+  --mcksi-frame-include: true;
+}

--- a/apps/mocksi-lite/content/spinner.css
+++ b/apps/mocksi-lite/content/spinner.css
@@ -17,4 +17,8 @@
     100% {
         transform: rotate(360deg);
     }
-} 
+}
+
+.mcksi-frame-include {
+    --mcksi-frame-include: true;
+}

--- a/apps/mocksi-lite/package.json
+++ b/apps/mocksi-lite/package.json
@@ -15,17 +15,20 @@
 		"react-dom": "^18.1.0",
 		"tailwindcss": "^3.4.1",
 		"typescript": "5.3.3",
+		"vitest": "^2.0.1",
 		"xslt-processor": "^3.0.0"
 	},
 	"scripts": {
 		"dev": "extension dev",
 		"start": "extension start",
 		"build": "extension build",
+		"test": "vitest",
 		"lint": "biome ci .",
 		"format": "biome check --apply . && biome lint --apply ."
 	},
 	"dependencies": {
 		"@repo/harlight": "workspace:*",
+		"@repo/reactor": "workspace:*",
 		"@rollbar/react": "0.12.0-beta",
 		"auth0-js": "^9.26.1",
 		"react-draggable": "^4.4.6",

--- a/apps/mocksi-lite/package.json
+++ b/apps/mocksi-lite/package.json
@@ -29,6 +29,7 @@
 	"dependencies": {
 		"@repo/harlight": "workspace:*",
 		"@repo/reactor": "workspace:*",
+		"@repo/dodom": "workspace:*",
 		"@rollbar/react": "0.12.0-beta",
 		"auth0-js": "^9.26.1",
 		"react-draggable": "^4.4.6",

--- a/apps/mocksi-lite/tailwind.config.js
+++ b/apps/mocksi-lite/tailwind.config.js
@@ -8,6 +8,12 @@ module.exports = {
 	],
 	theme: {
 		extend: {
+			// Extend the utilities
+			utilities: {
+				".mcksi-frame-include": {
+					"--mcksi-frame-include": "true",
+				},
+			},
 			colors: {
 				grey: "#819590",
 				green: "#006C52",

--- a/apps/mocksi-lite/tests/utils.test.ts
+++ b/apps/mocksi-lite/tests/utils.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { extractStyles } from "../utils";
+
+// Mock CSSStyleRule
+class MockCSSStyleRule {
+	cssText: string;
+	style: { getPropertyValue: (prop: string) => string };
+
+	constructor(cssText: string, include: boolean) {
+		this.cssText = cssText;
+		this.style = {
+			getPropertyValue: (prop: string) =>
+				prop === "--mcksi-frame-include" && include ? "true" : "",
+		};
+	}
+}
+
+describe("extractStyles", () => {
+	it('should extract styles from the stylesheets that contain the "--mcksi-frame-include: true;" rule', () => {
+		// Mock CSSStyleSheet and CSSRule
+		const mockCSSRule = (cssText: string, include: boolean): CSSRule =>
+			new MockCSSStyleRule(cssText, include) as unknown as CSSRule;
+
+		const mockCSSStyleSheet = (
+			href: string | null,
+			rules: CSSRule[],
+		): CSSStyleSheet =>
+			({
+				href,
+				cssRules: rules,
+			}) as unknown as CSSStyleSheet;
+
+		// Create mock stylesheets
+		const stylesheets = [
+			mockCSSStyleSheet(null, [mockCSSRule("body { color: red; }", true)]),
+			mockCSSStyleSheet(null, [mockCSSRule("body { color: blue; }", false)]),
+			mockCSSStyleSheet("http://example.com/style.css", [
+				mockCSSRule("body { color: green; }", true),
+			]),
+			mockCSSStyleSheet(null, [mockCSSRule("body { color: yellow; }", true)]),
+			mockCSSStyleSheet(null, [mockCSSRule("body { color: black; }", true)]),
+			mockCSSStyleSheet(null, [mockCSSRule("body { color: white; }", true)]),
+		];
+
+		// Call the function
+		const result = extractStyles(
+			stylesheets as unknown as DocumentOrShadowRoot["styleSheets"],
+		);
+
+		// Assert the result
+		expect(result).toContain("body { color: red; }");
+		expect(result).toContain("body { color: yellow; }");
+		expect(result).toContain("body { color: black; }");
+		expect(result).toContain("body { color: white; }");
+		expect(result).not.toContain("body { color: blue; }");
+		expect(result).not.toContain("body { color: green; }");
+	});
+
+	it("should handle errors gracefully", () => {
+		// Mock CSSStyleSheet and CSSRule
+		const mockCSSStyleSheetWithError = (): CSSStyleSheet =>
+			({
+				href: null,
+				get cssRules() {
+					throw new Error("Access denied");
+				},
+			}) as unknown as CSSStyleSheet;
+
+		// Create mock stylesheets
+		const stylesheets = [mockCSSStyleSheetWithError()];
+
+		// Spy on console.error
+		const consoleErrorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		// Call the function
+		const result = extractStyles(
+			stylesheets as unknown as DocumentOrShadowRoot["styleSheets"],
+		);
+
+		// Assert the result
+		expect(result).toBe("");
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			"Error accessing stylesheet:",
+			expect.any(Error),
+		);
+
+		// Restore console.error
+		consoleErrorSpy.mockRestore();
+	});
+});

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -403,3 +403,42 @@ export const innerHTMLToJson = (innerHTML: string): string => {
 
 	return JSON.stringify(body);
 };
+
+// This function is used to extract styles from the stylesheets that contain the "--mcksi-frame-include: true;" rule
+export const extractStyles = (
+	stylesheets: DocumentOrShadowRoot["styleSheets"],
+): string => {
+	let styles = "";
+	const styleSheets = Array.from(stylesheets) as CSSStyleSheet[];
+	for (const sheet of styleSheets) {
+		// Skip external stylesheets
+		if (sheet.href) {
+			continue;
+		}
+		try {
+			if (sheet.cssRules) {
+				const cssRules = Array.from(sheet.cssRules) as CSSRule[];
+				// Check if the stylesheet contains the "--mcksi-frame-include: true;" rule
+				const includesMcksiFrameInclude = cssRules.some((rule) => {
+					if ("style" in rule) {
+						return (
+							(rule as CSSStyleRule).style.getPropertyValue(
+								"--mcksi-frame-include",
+							) === "true"
+						);
+					}
+					return false;
+				});
+				if (includesMcksiFrameInclude) {
+					for (const rule of cssRules) {
+						styles += `${rule.cssText}\n`;
+					}
+				}
+			}
+		} catch (e) {
+			console.error("Error accessing stylesheet:", e);
+		}
+	}
+
+	return styles.trim();
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@repo/harlight": "workspace:*",
+    "@repo/reactor": "workspace:*",
     "@repo/dodom": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@repo/harlight':
         specifier: workspace:*
         version: link:../../packages/harlight
+      '@repo/reactor':
+        specifier: workspace:*
+        version: link:../../packages/reactor
       '@rollbar/react':
         specifier: 0.12.0-beta
         version: 0.12.0-beta(prop-types@15.8.1)(react@18.3.1)(rollbar@2.26.4)
@@ -103,6 +106,9 @@ importers:
       typescript:
         specifier: 5.3.3
         version: 5.3.3
+      vitest:
+        specifier: ^2.0.1
+        version: 2.0.2(@types/node@20.14.10)(jsdom@24.1.0)(less@4.2.0)(sass@1.77.8)(terser@5.31.2)
       xslt-processor:
         specifier: ^3.0.0
         version: 3.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@repo/harlight':
         specifier: workspace:*
         version: link:packages/harlight
+      '@repo/reactor':
+        specifier: workspace:*
+        version: link:packages/reactor
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -30,6 +33,9 @@ importers:
 
   apps/mocksi-lite:
     dependencies:
+      '@repo/dodom':
+        specifier: workspace:*
+        version: link:../../packages/dodom
       '@repo/harlight':
         specifier: workspace:*
         version: link:../../packages/harlight


### PR DESCRIPTION
- **less hacky fix for MOC-128, prevent external stylesheets from altering mocksi components**
- **add mocksi-lite unit tests to gha**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new testing job for `mocksi-lite` to enhance testing coverage.
	- Implemented the `extractStyles` utility function for better style extraction.
	- Added new CSS class `.mcksi-frame-include` across multiple stylesheets to improve styling options.
	- Updated Tailwind configuration to include the new utility class.

- **Bug Fixes**
	- Enhanced error handling within the `extractStyles` function to prevent crashes.

- **Tests**
	- Added unit tests for the `extractStyles` function using the Vitest framework.

- **Chores**
	- Updated `package.json` with new dependencies for testing and internal package integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->