### PR TITLE
Fix: Stop firing error for empty recordings list

### DIFF
--- a/apps/mocksi-lite/background.ts
+++ b/apps/mocksi-lite/background.ts
@@ -337,7 +337,6 @@ async function getRecordings(): Promise<Recording[]> {
 		});
 
 		if (!response || response.length === 0) {
-			MocksiRollbar.error("No recordings found.");
 			chrome.storage.local.set({ recordings: "[]" });
 			return [];
 		}


### PR DESCRIPTION
An empty recordings list is a valid state for both new and existing users who have deleted all their recordings. This change removes the unnecessary error notification when the recordings endpoint returns an empty list.

This fix prevents unnecessary alerts in Rollbar, specifically for https://app.rollbar.com/a/mocksi/fix/item/mocksi-lite/190#detail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling by removing unnecessary error logging when no recordings are found, resulting in a cleaner user experience.
  
- **Chores**
	- Enhanced code clarity by refining the logic for handling empty or null recording responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->