### PR TITLE
[MOC-100] center create new demo btn

### DIFF
--- a/apps/mocksi-lite/content/ListPopup/index.tsx
+++ b/apps/mocksi-lite/content/ListPopup/index.tsx
@@ -66,7 +66,9 @@ const ListPopup = ({ email, onChat, onClose, onLogout }: ListPopupProps) => {
 				) : null}
 				<Button
 					className={
-						!recordings.length ? "mw-mt-3 self-center" : "mw-my-3 self-center"
+						!recordings.length
+							? "mw-mt-3 mw-self-center"
+							: "mw-my-3 mw-self-center"
 					}
 					onClick={handleCreateDemoClicked}
 				>

--- a/apps/mocksi-lite/content/ListPopup/index.tsx
+++ b/apps/mocksi-lite/content/ListPopup/index.tsx
@@ -3,15 +3,15 @@ import type { Recording } from "../../background";
 import Button from "../../common/Button";
 import Divider from "../../common/Divider";
 import Popup from "../../common/Popup";
-import { getRecordingsStorage, sendMessage } from "../../utils";
+import { sendMessage } from "../../utils";
 import { AppEvent, AppStateContext } from "../AppStateContext";
 import DemoItem from "./DemoItem";
 
 interface ListPopupProps {
-	onClose: () => void;
-	onChat: () => void;
-	onLogout: () => void;
 	email?: string;
+	onChat: () => void;
+	onClose: () => void;
+	onLogout: () => void;
 }
 
 const ListPopup = ({ email, onChat, onClose, onLogout }: ListPopupProps) => {
@@ -42,22 +42,22 @@ const ListPopup = ({ email, onChat, onClose, onLogout }: ListPopupProps) => {
 
 	return (
 		<Popup
-			shouldDisplayFooter
 			email={email}
-			onSettings={handleSettingsClicked}
-			onLogout={onLogout}
 			onChat={onChat}
 			onClose={onClose}
+			onLogout={onLogout}
+			onSettings={handleSettingsClicked}
+			shouldDisplayFooter
 		>
-			<div className="mw-flex mw-flex-1 mw-flex-col mw-h-[280px] mw-overflow-x-scroll">
+			<div className="mw-flex mw-flex-col mw-flex-1 mw-h-[280px] mw-overflow-x-scroll">
 				{recordings.length ? (
-					<div className="mw-flex-1 mw-flex mw-flex-col mw-py-8 mw-overflow-y-scroll">
+					<div className="mw-flex mw-flex-col mw-flex-1 mw-py-8 mw-overflow-y-scroll">
 						{recordings
 							.filter((record) => record.url)
 							.map((record) => (
 								<Fragment key={`demo-item-${record.uuid}`}>
 									<DemoItem {...record} />
-									<div className="mw-px-3 mw-w-full mw-my-6">
+									<div className="mw-my-6 mw-px-3 mw-w-full">
 										<Divider />
 									</div>
 								</Fragment>
@@ -65,10 +65,10 @@ const ListPopup = ({ email, onChat, onClose, onLogout }: ListPopupProps) => {
 					</div>
 				) : null}
 				<Button
-					onClick={handleCreateDemoClicked}
 					className={
 						!recordings.length ? "mw-mt-3 self-center" : "mw-my-3 self-center"
 					}
+					onClick={handleCreateDemoClicked}
 				>
 					Create New Demo
 				</Button>


### PR DESCRIPTION
1. removes unused import
2. sorts properties and fields
3. fixes broken css , add mx-prefix to class, button is correctly centered now

<img width="516" alt="Screenshot 2024-08-01 at 1 31 38 PM" src="https://github.com/user-attachments/assets/a7d84e8f-d5f3-4b3c-9362-a701c36c0e42">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Improved clarity of the `ListPopup` component's props by repositioning and explicitly defining the `onClose` prop as optional.
	- Reorganized the order of props passed to the `Popup` component for better readability and maintainability.
	- Adjusted JSX structure to maintain consistent styling and enhance the overall clarity of the component.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->