### PR TITLE
[MOC-131] fix vertical height of recordings list container in popup

### DIFF
--- a/apps/mocksi-lite/content/ListPopup/index.tsx
+++ b/apps/mocksi-lite/content/ListPopup/index.tsx
@@ -49,7 +49,7 @@ const ListPopup = ({ email, onChat, onClose, onLogout }: ListPopupProps) => {
 			onSettings={handleSettingsClicked}
 			shouldDisplayFooter
 		>
-			<div className="mw-flex mw-flex-col mw-flex-1 mw-h-[280px] mw-overflow-x-scroll">
+			<div className="mw-flex mw-flex-col mw-flex-1 mw-h-full mw-overflow-x-scroll">
 				{recordings.length ? (
 					<div className="mw-flex mw-flex-col mw-flex-1 mw-py-8 mw-overflow-y-scroll">
 						{recordings


### PR DESCRIPTION
fix - class updated from `mw-h-[280px]` to `mw-h-full` resulting in scrollable area that takes up available height

<img width="516" alt="Screenshot 2024-08-01 at 2 52 57 PM" src="https://github.com/user-attachments/assets/0a64e419-252c-413d-8bee-dd0ce7385bbe">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the ListPopup component to have a flexible height, improving responsiveness based on content size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->