### PR TITLE
Fix MOC-144 by adding webpack import magic comments

### DIFF
--- a/apps/mocksi-lite/content/ContentApp.tsx
+++ b/apps/mocksi-lite/content/ContentApp.tsx
@@ -18,8 +18,24 @@ import EditToast from "./Toast/EditToast";
 import PlayToast from "./Toast/PlayToast";
 import RecordingToast from "./Toast/RecordingToast";
 
-import("./content.css");
-import("./base.css");
+import(
+	/* webpackChunkName: "content_content_css" */
+	/* webpackPrefetch: true */
+	/* webpackPreload: true */
+	"./content.css"
+);
+import(
+	/* webpackChunkName: "content_base_css" */
+	/* webpackPrefetch: true */
+	/* webpackPreload: true */
+	"./base.css"
+);
+import(
+	/* webpackChunkName: "content_spinner_css" */
+	/* webpackPrefetch: true */
+	/* webpackPreload: true */
+	"./spinner.css"
+);
 
 interface ContentProps {
 	isOpen?: boolean;

--- a/apps/mocksi-lite/content/LoadingSpinner.tsx
+++ b/apps/mocksi-lite/content/LoadingSpinner.tsx
@@ -1,2 +1,1 @@
-
 export const LoadingSpinner = () => <span id="loader" />;

--- a/apps/mocksi-lite/content/LoadingSpinner.tsx
+++ b/apps/mocksi-lite/content/LoadingSpinner.tsx
@@ -1,1 +1,2 @@
+
 export const LoadingSpinner = () => <span id="loader" />;

--- a/apps/mocksi-lite/content/RecordButton.tsx
+++ b/apps/mocksi-lite/content/RecordButton.tsx
@@ -2,7 +2,6 @@ import { useContext } from "react";
 import recordIcon from "../public/record-icon.png";
 import { AppEvent, AppState, AppStateContext } from "./AppStateContext";
 import { LoadingSpinner } from "./LoadingSpinner";
-import("./spinner.css");
 
 const waitTime = 2000; // 2 seconds
 

--- a/apps/mocksi-lite/manifest.json
+++ b/apps/mocksi-lite/manifest.json
@@ -38,6 +38,7 @@
 				"./content/content.tsx",
 				"/*.map",
 				"web_accessible_resources/*",
+				"web_accessible_resources/*.js",
 				"/*.json",
 				"/*.js",
 				"/*.css"


### PR DESCRIPTION
I'm not entirely sure what introduced this particular issue, but from the references below
preloading our stylesheets should get rid of it.

* https://webpack.js.org/api/module-methods/#magic-comments
* https://rollbar.com/blog/javascript-chunk-load-error/
* https://www.codemzy.com/blog/fix-chunkloaderror-react
* https://app.rollbar.com/a/mocksi/fix/item/mocksi-lite/212
* https://webpack.js.org/guides/code-splitting/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved CSS file loading performance through dynamic imports in the ContentApp, enhancing user experience.
	- Added `spinner.css` for better loading state visuals.

- **Bug Fixes**
	- Removed unnecessary CSS import in RecordButton, streamlining component dependencies.

- **Enhancements**
	- Expanded accessibility of JavaScript files in the manifest, enabling broader integration with web content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->