### PR TITLE
changed the way we use observe url

### DIFF
--- a/apps/mocksi-lite/content/Toast/EditToast.tsx
+++ b/apps/mocksi-lite/content/Toast/EditToast.tsx
@@ -10,6 +10,7 @@ import {
 import {
 	getAlterations,
 	loadAlterations,
+	loadPreviousModifications,
 	persistModifications,
 	recordingLabel,
 	sendMessage,
@@ -65,6 +66,7 @@ const EditToast = ({ initialReadOnlyState }: EditToastProps) => {
 	);
 	const [alterations, setAlterations] = useState<Alteration[]>([]);
 	const [recordingId, setRecordingId] = useState<string | null>(null);
+	const [url, setUrl] = useState<string>(document.location.href);
 
 	useEffect(() => {
 		// get alterations that were set in DemoItem.tsx and load them into state
@@ -78,11 +80,11 @@ const EditToast = ({ initialReadOnlyState }: EditToastProps) => {
 				}
 				setRecordingId(recordingId);
 
-				const alterations = result[MOCKSI_ALTERATIONS] || [];
-				setAlterations(alterations);
+				const storedAlterations = result[MOCKSI_ALTERATIONS];
+				setAlterations(storedAlterations);
 
 				// TODO: would be nice if it was like loadAlterations(alterations, { withHighlights: true })
-				loadAlterations(alterations, { withHighlights: true });
+				loadAlterations(storedAlterations, { withHighlights: areChangesHighlighted });
 
 				setupEditor();
 			})
@@ -91,11 +93,19 @@ const EditToast = ({ initialReadOnlyState }: EditToastProps) => {
 			});
 	}, []);
 
+	// Each time the URL updates we want to remove the existing highlights, and reload the alterations onto the page
+	useEffect(() => {
+		getHighlighter().removeHighlightNodes();
+		loadAlterations(alterations, { withHighlights: areChangesHighlighted });
+	}, [url])
+
 	const setupEditor = async () => {
 		sendMessage("attachDebugger");
 
+		// Whenever the url changes, we want to update the url in state which triggers the
+		// use effect that removes the highlights and reloads the alterations
 		observeUrlChange(() => {
-			loadAlterations(alterations, { withHighlights: true });
+			setUrl(document.location.href);
 		});
 
 		const results = await chrome.storage.local.get([MOCKSI_READONLY_STATE]);

--- a/apps/mocksi-lite/content/Toast/EditToast.tsx
+++ b/apps/mocksi-lite/content/Toast/EditToast.tsx
@@ -68,6 +68,7 @@ const EditToast = ({ initialReadOnlyState }: EditToastProps) => {
 	const [recordingId, setRecordingId] = useState<string | null>(null);
 	const [url, setUrl] = useState<string>(document.location.href);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: only run this on mount
 	useEffect(() => {
 		// get alterations that were set in DemoItem.tsx and load them into state
 		chrome.storage.local
@@ -84,7 +85,9 @@ const EditToast = ({ initialReadOnlyState }: EditToastProps) => {
 				setAlterations(storedAlterations);
 
 				// TODO: would be nice if it was like loadAlterations(alterations, { withHighlights: true })
-				loadAlterations(storedAlterations, { withHighlights: areChangesHighlighted });
+				loadAlterations(storedAlterations, {
+					withHighlights: areChangesHighlighted,
+				});
 
 				setupEditor();
 			})
@@ -94,10 +97,11 @@ const EditToast = ({ initialReadOnlyState }: EditToastProps) => {
 	}, []);
 
 	// Each time the URL updates we want to remove the existing highlights, and reload the alterations onto the page
+	// biome-ignore lint/correctness/useExhaustiveDependencies: we dont use the url but want to run this whenever it changes
 	useEffect(() => {
 		getHighlighter().removeHighlightNodes();
 		loadAlterations(alterations, { withHighlights: areChangesHighlighted });
-	}, [url])
+	}, [url]);
 
 	const setupEditor = async () => {
 		sendMessage("attachDebugger");


### PR DESCRIPTION
changed the way we use `observeUrlChange` to change a state which triggers a use effect

this is because the previous usage of the `observeUrlChange` callback didn't have access to the scope outside and couldn't get the latest alterations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the EditToast component to manage URL changes and alterations more effectively.
	- Introduced a new function to load previous modifications.

- **Improvements**
	- Improved responsiveness of the component to URL changes, enhancing user interaction by removing highlights and reloading alterations as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->