### PR TITLE
fixed an issue where you could set alterations to null

### DIFF
--- a/apps/mocksi-lite/content/Toast/EditToast.tsx
+++ b/apps/mocksi-lite/content/Toast/EditToast.tsx
@@ -82,7 +82,9 @@ const EditToast = ({ initialReadOnlyState }: EditToastProps) => {
 				setRecordingId(recordingId);
 
 				const storedAlterations = result[MOCKSI_ALTERATIONS];
-				setAlterations(storedAlterations);
+				if (storedAlterations) {
+					setAlterations(storedAlterations);
+				}
 
 				// TODO: would be nice if it was like loadAlterations(alterations, { withHighlights: true })
 				loadAlterations(storedAlterations, {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of the EditToast component by ensuring state is only set when valid alterations are provided, preventing potential issues with undefined values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->