### PR TITLE
reset alterations before apply new on page change

### DIFF
--- a/apps/mocksi-lite/content/Toast/EditToast.tsx
+++ b/apps/mocksi-lite/content/Toast/EditToast.tsx
@@ -102,6 +102,7 @@ const EditToast = ({ initialReadOnlyState }: EditToastProps) => {
 	// biome-ignore lint/correctness/useExhaustiveDependencies: we dont use the url but want to run this whenever it changes
 	useEffect(() => {
 		getHighlighter().removeHighlightNodes();
+		loadPreviousModifications(alterations);
 		loadAlterations(alterations, { withHighlights: areChangesHighlighted });
 	}, [url]);
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/883570a2-2d24-4160-b1eb-85dceb0849ed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `EditToast` component to load previous modifications alongside current alterations, improving the rendering logic.
  
- **Bug Fixes**
	- Addressed an issue ensuring that previous changes are now considered before applying new alterations, enhancing overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->