### PR TITLE
iterate entire body when apply alterations

### DIFF
--- a/apps/mocksi-lite/content/EditMode/utils.ts
+++ b/apps/mocksi-lite/content/EditMode/utils.ts
@@ -17,7 +17,9 @@ export const buildQuerySelector = (
 		keyToSave += `#${id}`;
 	}
 	if (classList.length) {
-		const filteredClasses = [...classList].filter((cls) => !(cls.includes(":") || cls.includes(".")));
+		const filteredClasses = [...classList].filter(
+			(cls) => !(cls.includes(":") || cls.includes(".")),
+		);
 		keyToSave += `.${filteredClasses.join(".")}`;
 	}
 	let elements: NodeListOf<Element>;

--- a/apps/mocksi-lite/content/EditMode/utils.ts
+++ b/apps/mocksi-lite/content/EditMode/utils.ts
@@ -17,7 +17,7 @@ export const buildQuerySelector = (
 		keyToSave += `#${id}`;
 	}
 	if (classList.length) {
-		const filteredClasses = [...classList].filter((cls) => !cls.includes(":"));
+		const filteredClasses = [...classList].filter((cls) => !(cls.includes(":") || cls.includes(".")));
 		keyToSave += `.${filteredClasses.join(".")}`;
 	}
 	let elements: NodeListOf<Element>;

--- a/apps/mocksi-lite/utils.ts
+++ b/apps/mocksi-lite/utils.ts
@@ -122,10 +122,11 @@ export const loadAlterations = async (
 	for (const alteration of alterations) {
 		const { selector, dom_after, dom_before, type } = alteration;
 		const elemToModify = getHTMLElementFromSelector(selector);
-		if (elemToModify) {
+		const body = document.querySelector("body");
+		if (body) {
 			if (type === "text") {
 				domManipulator.iterateAndReplace(
-					elemToModify as Node,
+					body as Node,
 					new RegExp(dom_before, "gi"),
 					sanitizeHtml(dom_after),
 					withHighlights,


### PR DESCRIPTION

https://github.com/user-attachments/assets/abdac368-85ac-4309-b08c-4dd5171fc095



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced filtering logic for class names, excluding both colons (:) and periods (.) for improved selector generation.
	- Expanded text modification scope to apply changes to the entire document body, rather than a specific element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->