### PR TITLE
escape css classes when building selector

### DIFF
--- a/apps/mocksi-lite/content/EditMode/utils.ts
+++ b/apps/mocksi-lite/content/EditMode/utils.ts
@@ -17,10 +17,8 @@ export const buildQuerySelector = (
 		keyToSave += `#${id}`;
 	}
 	if (classList.length) {
-		const filteredClasses = [...classList].filter(
-			(cls) => !(cls.includes(":") || cls.includes(".")),
-		);
-		keyToSave += `.${filteredClasses.join(".")}`;
+		const escapedClasses = [...classList].map((cls) => CSS.escape(cls));
+		keyToSave += `.${escapedClasses.join(".")}`;
 	}
 	let elements: NodeListOf<Element>;
 	try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the robustness of CSS selector construction by implementing improved handling of class names to prevent issues with invalid selectors.
  
- **Bug Fixes**
	- Fixed potential issues with class names containing special characters by ensuring all class names are properly escaped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->