### PR TITLE
chrome extension (development) id should always be static

### DIFF
--- a/apps/mocksi-lite-next/manifest.json
+++ b/apps/mocksi-lite-next/manifest.json
@@ -24,6 +24,7 @@
   "icons": {
     "128": "mocksi-logo.png"
   },
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtdeTUTUuHZx1xSvDuISF7wJP8nEPwW4vP8zTkdfdtb/1wM0JJ7XFeUHSIiq8l4Cs6/2f8tpK6MspeD7WhwuFWFHA2GWKoLSP0keuuBAhUFKrfISlNwFaNLX5LRkLSZQnr0ujIznvEuRZaXydIYR1e9pdhYTIcp2ToHW4CI02FUBtJVUUVeKGDiKKlKUrxwGtt1ecGZwVrQ1t7dj3DLrKguw1bONtoczFT3cCs9oVYg4l8frzlyI6xfsX8ynd4F+xS6+gYQ3aJBj7phAWHGAxbVRxTAzpzXRkb9A3ne31Ysjy4uYF9x7fK6NvDj/cm+EEfGDb3VmyXvOa3zeerXtdmwIDAQAB",
   "manifest_version": 3,
   "name": "Mocksi Lite: Next",
   "permissions": [


### PR DESCRIPTION
added "public" key to manifest.json which is used to create the chrome extension id, now the id should not change
hpbepdaeenaphhfpikjnflmginblmipn

when we publish the app we will get a static id


I tested this locally and I got the same id each time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a cryptographic key to the application manifest, enhancing secure identification and authentication capabilities.
  
- **Impact**
  - This change may improve interactions with other services requiring secure communication or verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->