### PR TITLE
MOC-225: remove floating mocksi icon

### DIFF
--- a/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
+++ b/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
@@ -107,10 +107,10 @@ chrome.runtime.onMessage.addListener((request) => {
                     break;
                   case "MINIMIZED":
                     styles = {
-                      bottom: "10px",
-                      height: "100px",
+                      bottom: "auto",
+                      height: "0",
                       top: "auto",
-                      width: "100px",
+                      width: "0",
                     };
                     break;
                   default:


### PR DESCRIPTION
Dependent PR: [ MOC-225_remove-floating-mocksi-icon](https://github.com/Mocksi/nest/pull/31)

Visibility of popup to be handled here, messages are still sent from nest to request that the popup is closed when user clicks x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Chrome extension's user interface by allowing it to fully collapse when minimized, improving the overall user experience. 

- **Style**
	- Adjusted styling properties for minimized state, ensuring the extension element becomes invisible and does not occupy space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->