### PR TITLE
Add flags to replaceAll

### DIFF
--- a/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
+++ b/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
@@ -78,6 +78,7 @@ chrome.runtime.onMessage.addListener((request) => {
       async function findReplaceAll(
         find: string,
         replace: string,
+        flags: string, 
         highlight: boolean,
       ) {
         const modification: ModificationRequest = {
@@ -85,7 +86,7 @@ chrome.runtime.onMessage.addListener((request) => {
           modifications: [
             {
               action: "replaceAll",
-              content: `/${find}/${replace}/`,
+              content: `/${find}/${replace}/${flags}`,
               selector: "body",
             },
           ],
@@ -118,8 +119,8 @@ chrome.runtime.onMessage.addListener((request) => {
               }
               if (request.message === "NEW_EDIT") {
                 if (request.data) {
-                  const { find, highlightEdits, replace } = request.data;
-                  await findReplaceAll(find, replace, highlightEdits);
+                  const { find, highlightEdits, replace, flags } = request.data;
+                  await findReplaceAll(find, replace, flags, highlightEdits);
                   data = Array.from(reactor.getAppliedModifications()).map(
                     (mod) => mod.modificationRequest,
                   );

--- a/packages/reactor/tests/main.test.ts
+++ b/packages/reactor/tests/main.test.ts
@@ -36,7 +36,7 @@ describe("modifyHtml", () => {
 				{
 					xpath: "//html/body/div",
 					action: "replaceAll",
-					content: "/train/brain/",
+					content: "/train/brain/i",
 				},
 			],
 		});

--- a/packages/reactor/tests/modifications.test.ts
+++ b/packages/reactor/tests/modifications.test.ts
@@ -45,7 +45,7 @@ describe("Utils", () => {
 		it("should replace all content correctly", async () => {
 			const modification: Modification = {
 				action: "replaceAll",
-				content: "/old/new/",
+				content: "/old/new/i",
 			};
 
 			const element = doc.createElement("div");
@@ -74,7 +74,7 @@ describe("Utils", () => {
 		it("should preserve capitals in replacement", async () => {
 			const modification: Modification = {
 				action: "replaceAll",
-				content: "/old/new/",
+				content: "/old/new/i",
 			};
 
 			const element = doc.createElement("div");
@@ -88,7 +88,7 @@ describe("Utils", () => {
 		it("should preserve plurals in replacement", async () => {
 			const modification: Modification = {
 				action: "replaceAll",
-				content: "/train/brain/",
+				content: "/train/brain/ip",
 			};
 
 			const element = doc.createElement("div");
@@ -104,7 +104,7 @@ describe("Utils", () => {
 		it("should only replace whole words", async () => {
 			const modification: Modification = {
 				action: "replaceAll",
-				content: "/train/brain/",
+				content: "/train/brain/wip",
 			};
 
 			const element = doc.createElement("div");
@@ -121,7 +121,7 @@ describe("Utils", () => {
 		it("should handle more complicated HTML", async () => {
 			const modification: Modification = {
 				action: "replaceAll",
-				content: "/train/brain/",
+				content: "/train/brain/wip",
 			};
 
 			const element = doc.createElement("div");
@@ -156,7 +156,7 @@ describe("Utils", () => {
 		it("should work with multiple text nodes", async () => {
 			const modification: Modification = {
 				action: "replaceAll",
-				content: "/train/brain/",
+				content: "/train/brain/wip",
 			};
 
 			const element = doc.createElement("div");

--- a/packages/reactor/tests/mutation.test.ts
+++ b/packages/reactor/tests/mutation.test.ts
@@ -29,7 +29,7 @@ describe("test mutation listeners", {}, () => {
                 {
                     selector: "body",
                     action: "replaceAll",
-                    content: "/train/brain/",
+                    content: "/train/brain/wip",
                 }
             ],
         };


### PR DESCRIPTION
Fixes MOC-241
Fixes MOC-242
Fixes MOC-239

Added flags to find/replace - the form is now:
`/find/replace/flags `
Where flags are:
  * i - case insensitive
  * w - whole word
  * p - plural
 For example:
`/Train/brain/wp`
Would match 'Train' with 'Brain' and 'Trains' with 'Brains', but not 'train' or 'sTrain'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced find-and-replace functionality with the addition of regex flags for more flexible operations.
	- Improved text replacement logic to support pluralization and word boundaries based on user-defined flags.

- **Bug Fixes**
	- Updated test cases to reflect changes in regex patterns, ensuring accurate functionality and case-insensitive matching.

- **Tests**
	- Modified various test cases to incorporate new regex patterns and flags, enhancing test coverage for replacement operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->