### PR TITLE
Allow users to specify the build environment when manually triggering the workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,16 @@ name: Build and Zip Extension
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to build the extension for'
+        required: true
+        default: 'development'
+        type: choice
+        options:
+        - production
+        - staging
+        - development
 
 defaults:
   run:
@@ -40,13 +50,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
-        # Set EXTENSION_ENV variable to the current branch name
-      - name: Set EXTENSION_ENV variable
-        run: echo "EXTENSION_ENV=${GITHUB_REF##refs/heads/}" | sed 's/\//-/g' >> $GITHUB_ENV
       - name: Build artifacts
         run: pnpm build
         env:
-          EXTENSION_ENV: ${{ env.EXTENSION_ENV }}
+          EXTENSION_ENV: ${{ inputs.environment }}
 
       - name: Upload extension artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Added a new input parameter 'environment' to the workflow_dispatch event in the GitHub Actions configuration.
- The 'environment' input allows users to specify the build environment (choices: production, staging, or development) when manually triggering the workflow.
- Removed the previous method where the EXTENSION_ENV variable was set based on the current branch name.
- Updated the build step to use the user-defined 'environment' input instead of the previously utilized branch name for the EXTENSION_ENV variable.
- This change improves the flexibility and clarity of environment configuration during the CI build process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new input parameter for the build workflow, allowing users to specify the environment (production, staging, development) for which the extension should be built.
	- Enhanced flexibility in the build process by enabling explicit user input for the build environment.

- **Improvements**
	- Streamlined the logic for setting the build environment variable, improving control and predictability in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->