### PR TITLE
Message iframe style for v1

### DIFF
--- a/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
+++ b/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
@@ -188,7 +188,7 @@ chrome.runtime.onMessage.addListener((request) => {
 
               // Resize iframe with the new styles
               if (iframeRef.current) {
-                if (request.data.iframe) {
+                if (request.data && request.data.iframe) {
                   // v1 iframe size / position pattern
                   const styles = getIframeSizePosition(request.data.iframe);
                   Object.assign(iframeRef.current.style, styles);

--- a/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
+++ b/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
@@ -188,7 +188,7 @@ chrome.runtime.onMessage.addListener((request) => {
 
               // Resize iframe with the new styles
               if (iframeRef.current) {
-                if (request.data && request.data.iframe) {
+                if (request.data?.iframe) {
                   // v1 iframe size / position pattern
                   const styles = getIframeSizePosition(request.data.iframe);
                   Object.assign(iframeRef.current.style, styles);

--- a/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
+++ b/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
@@ -156,7 +156,6 @@ chrome.runtime.onMessage.addListener((request) => {
       React.useEffect(() => {
         chrome.runtime.onMessage.addListener(
           (request, _sender, sendResponse) => {
-            console.log(request);
             // execute in async block so that we return true
             // synchronously, telling chrome to wait for the response
             (async () => {

--- a/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
+++ b/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
@@ -47,7 +47,7 @@ function getIframeSizePosition({
 
   const styles = {
     bottom: "auto",
-    display: "inherit",
+    display: "block",
     height: `${height}px`,
     left: "auto",
     right: "auto",

--- a/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
+++ b/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
@@ -188,9 +188,11 @@ chrome.runtime.onMessage.addListener((request) => {
               // Resize iframe with the new styles
               if (iframeRef.current) {
                 if (request.data.iframe) {
+                  // v1 iframe size / position pattern
                   const styles = getIframeSizePosition(request.data.iframe);
                   Object.assign(iframeRef.current.style, styles);
                 } else {
+                  // v0+
                   const styles = getIframeStyles(request.message);
                   Object.assign(iframeRef.current.style, styles);
                 }
@@ -223,6 +225,10 @@ chrome.runtime.onMessage.addListener((request) => {
                   height: "600px",
                   width: "500px",
                   inset: "auto 10px 10px auto",
+                  top: "auto",
+                  right: "10px",
+                  bottom: "10px",
+                  left: "auto",
                   boxShadow: "none",
                   zIndex: 99998,
                   border: "none",

--- a/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
+++ b/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
@@ -37,7 +37,9 @@ function getIframeSizePosition({
   width: number;
 }) {
   if (!height || !width || !position) {
-    console.log("could not update iframe size or position");
+    console.error(
+      "Cannot update iframe size / position, make sure 'request.data.iframe' has 'height', 'width', and 'position' set correctly",
+    );
     return;
   }
 

--- a/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
+++ b/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
@@ -27,6 +27,52 @@ window.addEventListener("message", (event: MessageEvent) => {
   }
 });
 
+function getIframeSizePosition({
+  height,
+  position,
+  width,
+}: {
+  height: number;
+  position: string;
+  width: number;
+}) {
+  if (!height || !width || !position) {
+    console.log("could not update iframe size or position");
+    return;
+  }
+
+  const bounds = document.body.getBoundingClientRect();
+
+  const styles = {
+    bottom: "auto",
+    display: "inherit",
+    height: `${height}px`,
+    left: "auto",
+    right: "auto",
+    top: "auto",
+    width: `${width}px`,
+  };
+
+  switch (position) {
+    case "BOTTOM_CENTER":
+      styles.bottom = "0px";
+      styles.right = `${bounds.width / 2 - width / 2}px`;
+      break;
+    case "BOTTOM_RIGHT":
+      styles.bottom = "10px";
+      styles.right = "10px";
+      break;
+    case "NONE":
+      styles.display = "none";
+      break;
+    case "TOP_RIGHT":
+      styles.top = "10px";
+      styles.right = "10px";
+      break;
+  }
+  return styles;
+}
+
 // Function to get styles based on the message,
 function getIframeStyles(message: string): Partial<CSSStyleDeclaration> {
   switch (message) {
@@ -110,6 +156,7 @@ chrome.runtime.onMessage.addListener((request) => {
       React.useEffect(() => {
         chrome.runtime.onMessage.addListener(
           (request, _sender, sendResponse) => {
+            console.log(request);
             // execute in async block so that we return true
             // synchronously, telling chrome to wait for the response
             (async () => {
@@ -140,6 +187,10 @@ chrome.runtime.onMessage.addListener((request) => {
 
               // Resize iframe with the new styles
               if (iframeRef.current) {
+                if (request.data.iframe) {
+                  const tempStyles = getIframeSizePosition(request.data.iframe);
+                  console.log(tempStyles);
+                }
                 const styles = getIframeStyles(request.message);
                 Object.assign(iframeRef.current.style, styles);
               }

--- a/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
+++ b/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
@@ -188,11 +188,12 @@ chrome.runtime.onMessage.addListener((request) => {
               // Resize iframe with the new styles
               if (iframeRef.current) {
                 if (request.data.iframe) {
-                  const tempStyles = getIframeSizePosition(request.data.iframe);
-                  console.log(tempStyles);
+                  const styles = getIframeSizePosition(request.data.iframe);
+                  Object.assign(iframeRef.current.style, styles);
+                } else {
+                  const styles = getIframeStyles(request.message);
+                  Object.assign(iframeRef.current.style, styles);
                 }
-                const styles = getIframeStyles(request.message);
-                Object.assign(iframeRef.current.style, styles);
               }
 
               sendResponse({

--- a/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
+++ b/apps/mocksi-lite-next/src/pages/content/mocksi-extension.tsx
@@ -225,7 +225,6 @@ chrome.runtime.onMessage.addListener((request) => {
                   display: "block",
                   height: "600px",
                   width: "500px",
-                  inset: "auto 10px 10px auto",
                   top: "auto",
                   right: "10px",
                   bottom: "10px",


### PR DESCRIPTION
Allows us to pass position and size to iframe via messaging, if no `request.data.iframe` is not sent in a message existing iframe styles function is applied making this backwards compatible 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced iframe responsiveness with a new function that calculates size and position based on incoming message data.
	- Improved style management for iframes, allowing for more precise control over their placement within the application.

- **Bug Fixes**
	- Updated logic to ensure proper handling of iframe styles when specific data is received, improving overall functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->