### PR TITLE
Add record for source maps to manifest in development mode

### DIFF
--- a/apps/mocksi-lite-next/vite.config.ts
+++ b/apps/mocksi-lite-next/vite.config.ts
@@ -50,6 +50,13 @@ export default defineConfig(({ mode }) => {
     case "development":
       manifest.name = "[Development] Mocksi Lite";
       manifest.key = DEV_UNPACKED_KEY;
+
+      // add permissions to view source map
+      manifest.web_accessible_resources.push({
+        matches: ["<all_urls>"],
+        resources: ["assets/*.js.map"],
+      })
+
       break;
     case "staging":
       manifest.name = "[Staging] Mocksi Lite";


### PR DESCRIPTION
Makes it so you can see the source when debugging the extension in development mode