### PR TITLE
Reactor cleanup for use in eval project

### DIFF
--- a/packages/reactor/index.ts
+++ b/packages/reactor/index.ts
@@ -4,8 +4,8 @@ export type {
   Highlighter,
   Modification,
   ModificationRequest,
-} from "./interfaces";
+} from "./interfaces.js";
 
-import Reactor from "./reactor";
+import Reactor from "./reactor.js";
 
 export { Reactor };

--- a/packages/reactor/interfaces.ts
+++ b/packages/reactor/interfaces.ts
@@ -1,4 +1,4 @@
-import { generateRandomString } from "./utils";
+import { generateRandomString } from "./utils.js";
 
 export type Modification = {
 	selector?: string;

--- a/packages/reactor/main.ts
+++ b/packages/reactor/main.ts
@@ -2,9 +2,9 @@ import type {
 	AppliedModifications,
 	DomJsonExportNode,
 	ModificationRequest,
-} from "./interfaces";
-import { generateModifications } from "./modifications";
-import { parseRequest } from "./utils";
+} from "./interfaces.js";
+import { generateModifications } from "./modifications.js";
+import { parseRequest } from "./utils.js";
 
 export async function modifyHtml(
 	htmlString: string,

--- a/packages/reactor/modifications.ts
+++ b/packages/reactor/modifications.ts
@@ -1,11 +1,11 @@
-import { AdjacentHTMLModification } from "./modifications/adjacentHTML";
-import { HighlightModification } from "./modifications/highlight";
-import { NoopModification } from "./modifications/noop";
-import { RemoveModification } from "./modifications/remove";
-import { ReplaceModification } from "./modifications/replace";
-import { ReplaceAllModification } from "./modifications/replaceAll";
-import { SwapImageModification } from "./modifications/swapImage";
-import { ToastModification } from "./modifications/toast";
+import { AdjacentHTMLModification } from "./modifications/adjacentHTML.js";
+import { HighlightModification } from "./modifications/highlight.js";
+import { NoopModification } from "./modifications/noop.js";
+import { RemoveModification } from "./modifications/remove.js";
+import { ReplaceModification } from "./modifications/replace.js";
+import { ReplaceAllModification } from "./modifications/replaceAll.js";
+import { SwapImageModification } from "./modifications/swapImage.js";
+import { ToastModification } from "./modifications/toast.js";
 
 import type {
 	AppliableModification,
@@ -13,7 +13,7 @@ import type {
 	Highlighter,
 	Modification,
 	ModificationRequest,
-} from "./interfaces";
+} from "./interfaces.js";
 
 export class AppliedModificationsImpl implements AppliedModifications {
 	modificationRequest: ModificationRequest;
@@ -70,9 +70,9 @@ export async function generateModifications(
 					// construct a new NodeListOf<Element> from items found by the xpath
 					elements = [];
 					if (!mod.xpath.startsWith("//html")) {
-						mod.xpath = `//html/${mod.xpath}`;
+						mod.xpath = `//html${mod.xpath}`;
 					}
-					const xpath = document.evaluate(
+					const xpath = window.document.evaluate(
 						mod.xpath,
 						doc,
 						null,
@@ -201,7 +201,7 @@ export function matchesSelector(element: Element, mod: Modification): boolean {
 	if (mod.selector) {
 		return element.matches(mod.selector);
 	} else if (mod.xpath) {
-		const xpathResult = document.evaluate(mod.xpath, document, null, XPathResult.BOOLEAN_TYPE, null);
+		const xpathResult = window.document.evaluate(mod.xpath, window.document, null, XPathResult.BOOLEAN_TYPE, null);
 		return xpathResult.booleanValue;
 	}
 

--- a/packages/reactor/modifications/adjacentHTML.ts
+++ b/packages/reactor/modifications/adjacentHTML.ts
@@ -1,4 +1,4 @@
-import { AppliableModification } from "../interfaces";
+import { AppliableModification } from "../interfaces.js";
 
 export class AdjacentHTMLModification extends AppliableModification {
 	elementId: string;

--- a/packages/reactor/modifications/highlight.ts
+++ b/packages/reactor/modifications/highlight.ts
@@ -1,4 +1,4 @@
-import { AppliableModification } from "../interfaces";
+import { AppliableModification } from "../interfaces.js";
 import * as cssSelector from "css-selector-generator";
 
 export class HighlightModification extends AppliableModification {

--- a/packages/reactor/modifications/noop.ts
+++ b/packages/reactor/modifications/noop.ts
@@ -1,4 +1,4 @@
-import { AppliableModification } from "../interfaces";
+import { AppliableModification } from "../interfaces.js";
 
 export class NoopModification extends AppliableModification {
 	action: string;

--- a/packages/reactor/modifications/remove.ts
+++ b/packages/reactor/modifications/remove.ts
@@ -1,4 +1,4 @@
-import { AppliableModification } from "../interfaces";
+import { AppliableModification } from "../interfaces.js";
 import * as cssSelector from "css-selector-generator";
 
 export class RemoveModification extends AppliableModification {

--- a/packages/reactor/modifications/replace.ts
+++ b/packages/reactor/modifications/replace.ts
@@ -1,4 +1,4 @@
-import { AppliableModification } from "../interfaces";
+import { AppliableModification } from "../interfaces.js";
 import * as cssSelector from "css-selector-generator";
 
 export class ReplaceModification extends AppliableModification {

--- a/packages/reactor/modifications/replaceAll.ts
+++ b/packages/reactor/modifications/replaceAll.ts
@@ -1,4 +1,4 @@
-import { AppliableModification } from "../interfaces";
+import { AppliableModification } from "../interfaces.js";
 
 export class ReplaceAllModification extends AppliableModification {
 	element: Element;
@@ -106,7 +106,7 @@ function walkTree(
 	const changeNodes: Node[] = [];
 	const changes: TreeChange[] = [];
 
-	const treeWalker = document.createTreeWalker(
+	const treeWalker = window.document.createTreeWalker(
 		rootElement,
 		NodeFilter.SHOW_TEXT,
 		(node) => {
@@ -195,7 +195,7 @@ function replaceText(
 
 		for (let i = 0; i < split.length; i++) {
 			if (typeof split[i] !== "undefined") {
-				const textNode = document.createTextNode(split[i] || "");
+				const textNode = window.document.createTextNode(split[i] || "");
 				parentElement.insertBefore(textNode, nextSibling);
 
 				if (i % 2 !== 0) {

--- a/packages/reactor/modifications/swapImage.ts
+++ b/packages/reactor/modifications/swapImage.ts
@@ -1,4 +1,4 @@
-import { AppliableModification } from "../interfaces";
+import { AppliableModification } from "../interfaces.js";
 import * as cssSelector from "css-selector-generator";
 
 export class SwapImageModification extends AppliableModification {

--- a/packages/reactor/modifications/toast.ts
+++ b/packages/reactor/modifications/toast.ts
@@ -1,4 +1,4 @@
-import { AppliableModification } from "../interfaces";
+import { AppliableModification } from "../interfaces.js";
 
 export class ToastModification extends AppliableModification {
 	message: string;

--- a/packages/reactor/mutationObserver.ts
+++ b/packages/reactor/mutationObserver.ts
@@ -1,6 +1,6 @@
-import Reactor from "./reactor";
-import { AppliedModificationsImpl } from "./modifications";
-import { applyModification, matchesSelector } from "./modifications";
+import Reactor from "./reactor.js";
+import { AppliedModificationsImpl } from "./modifications.js";
+import { applyModification, matchesSelector } from "./modifications.js";
 
 export class ReactorMutationObserver {
 	private reactor: Reactor;
@@ -42,7 +42,7 @@ export class ReactorMutationObserver {
 	}
 
 	walkAddedElements(element: Element) {
-		const treeWalker = document.createTreeWalker(
+		const treeWalker = window.document.createTreeWalker(
 			element,
 			NodeFilter.SHOW_ELEMENT,
 			null
@@ -68,7 +68,7 @@ export class ReactorMutationObserver {
 	}
 
 	walkRemovedElements(element: Element) {
-		const treeWalker = document.createTreeWalker(
+		const treeWalker = window.document.createTreeWalker(
 			element,
 			NodeFilter.SHOW_ELEMENT,
 			null

--- a/packages/reactor/reactor.ts
+++ b/packages/reactor/reactor.ts
@@ -3,13 +3,13 @@ import type {
   DomJsonExportNode,
   Highlighter,
   ModificationRequest,
-} from "./interfaces";
-import { htmlElementToJson } from "./main";
+} from "./interfaces.js";
+import { htmlElementToJson } from "./main.js";
 import {
   AppliedModificationsImpl,
   generateModifications,
-} from "./modifications";
-import { ReactorMutationObserver } from "./mutationObserver";
+} from "./modifications.js";
+import { ReactorMutationObserver } from "./mutationObserver.js";
 
 /**
  * Reactor applied modifications to the current page. Modifications

--- a/packages/reactor/tests/modifications.test.ts
+++ b/packages/reactor/tests/modifications.test.ts
@@ -11,7 +11,7 @@ describe("Utils", () => {
 
 	// Vitest beforeEach function for setup
 	beforeEach(() => {
-		doc = document.implementation.createHTMLDocument("Test Document");
+		doc = window.document.implementation.createHTMLDocument("Test Document");
 	});
 
 	describe("applyModification", () => {

--- a/packages/reactor/tests/mutation.test.ts
+++ b/packages/reactor/tests/mutation.test.ts
@@ -11,7 +11,7 @@ describe("test mutation listeners", {}, () => {
 
 	// Vitest beforeEach function for setup
 	beforeEach(() => {
-		doc = document.implementation.createHTMLDocument("Test Document");
+		doc = window.document.implementation.createHTMLDocument("Test Document");
         
         reactor = new Reactor();
         reactor.attach(doc, {

--- a/packages/reactor/tsconfig.json
+++ b/packages/reactor/tsconfig.json
@@ -7,7 +7,9 @@
 	  "module": "ESNext",
 	  "target": "ESNext",
 	  "esModuleInterop": true,
-	  "allowSyntheticDefaultImports": true
+	  "allowSyntheticDefaultImports": true,
+	  "strict": true,
+	  "forceConsistentCasingInFileNames": true
 	},
 	"include": ["index.ts", "receivers", "utils", "commands"],
 	"exclude": ["node_modules", "dist", "test"]

--- a/packages/reactor/utils.ts
+++ b/packages/reactor/utils.ts
@@ -1,6 +1,6 @@
 import type {
 	ModificationRequest,
-} from "./interfaces";
+} from "./interfaces.js";
 
 export function parseRequest(userRequest: string): ModificationRequest {
 	try {


### PR DESCRIPTION
1. It turns out ESM modules want your imports to specify a file extension, so I've switched all imports to include .js
2. When running outside a browser, a top-level document might not be defined (or might be inconsistent), so switch to consistently using window.document

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated import paths across various modules to include `.js` file extensions, enhancing compatibility with environments that require explicit file references.
  
- **Bug Fixes**
	- Clarified the scope of the `document` object by using `window.document` in multiple instances, ensuring consistent context in document manipulation.

- **Documentation**
	- Updated `tsconfig.json` to enforce strict type-checking and consistent casing in file names, improving overall code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->